### PR TITLE
Fix profile handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CURRENT_DIR = $(shell pwd)
 
 
 ifndef PROFILE
-	override PROFILE = "local,conda"
+	override PROFILE = "standard,conda"
 endif
 
 ifndef DEST

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All module configurations are the same as the full pipeline run with the sole di
 
 where
  *  /shared/directory/test is a directory that is shared between multiple machines.
- * PROFILE can be either `local` or `slurm` depending on which environment the pipeline should be executed.
+ * PROFILE can be either `standard` (local use) or `slurm` depending on which environment the pipeline should be executed.
 
 **Note!** Metabolomics part is currently excluded from full pipeline run.
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -242,7 +242,7 @@ profiles {
            }
      	}
     }
-    local { 
+    standard { 
          docker {
            fixOwnership = true
            enabled = true

--- a/scripts/test_SRA.sh
+++ b/scripts/test_SRA.sh
@@ -4,6 +4,6 @@ OPTIONS=$1
 YAML="${2:-example_params/SRA.yml}" 
 make run_small_full_test \
 	WORK_DIR="work" OPTIONS=" $OPTIONS " \
-       	PROFILE="local"  ENTRY="wSRATable" \
+       	PROFILE="standard"  ENTRY="wSRATable" \
 	PARAMS_FILE=$YAML
 make check

--- a/scripts/test_annotation.sh
+++ b/scripts/test_annotation.sh
@@ -3,7 +3,7 @@ YAML="${2:-example_params/annotation.yml}"
 WORK="${3:-work}"
 make run_small_full_test WORK_DIR=${WORK} \
 	OPTIONS=" $OPTIONS  " \
-	PROFILE="local" \
+	PROFILE="standard" \
 	ENTRY="wAnnotate" \
 	PARAMS_FILE=${YAML}
 make check

--- a/scripts/test_assembly.sh
+++ b/scripts/test_assembly.sh
@@ -5,6 +5,6 @@ YAML="${2:-example_params/assembly.yml}"
 WORK="${3:-work}"
 make run_small_full_test \
 	WORK_DIR=${WORK} OPTIONS=" $OPTIONS " \
-       	PROFILE="local"  ENTRY="wAssembly" \
+       	PROFILE="standard"  ENTRY="wAssembly" \
 	PARAMS_FILE=$YAML
 make check

--- a/scripts/test_cooccurrence.sh
+++ b/scripts/test_cooccurrence.sh
@@ -5,7 +5,7 @@ YAML="${2:-example_params/coocurrence.yml}"
 WORK="${3:-work}"
 make run_small_full_test \
 	WORK_DIR=${WORK} OPTIONS=" $OPTIONS " \
-       	PROFILE="local"  ENTRY="wCooccurrence" \
+       	PROFILE="standard"  ENTRY="wCooccurrence" \
 	PARAMS_FILE=$YAML
 
 make check

--- a/scripts/test_dereplication.sh
+++ b/scripts/test_dereplication.sh
@@ -5,7 +5,7 @@ YAML="${2:-example_params/dereplication.yml}"
 WORK="${3:-work}"
 make run_small_full_test \
 	WORK_DIR=${WORK} OPTIONS=" $OPTIONS " \
-       	PROFILE="local"  ENTRY="wDereplication" \
+       	PROFILE="standard"  ENTRY="wDereplication" \
 	PARAMS_FILE=$YAML
 
 make check

--- a/scripts/test_fragmentRecruitment.sh
+++ b/scripts/test_fragmentRecruitment.sh
@@ -5,7 +5,7 @@ YAML="${2:-example_params/fragmentRecruitment.yml}"
 WORK="${3:-work}"
 make run_small_full_test WORK_DIR=${WORK} \
 	OPTIONS=" $OPTIONS  " \
-	PROFILE="local" \
+	PROFILE="standard" \
 	ENTRY="wFragmentRecruitment" \
 	PARAMS_FILE=${YAML}
 make check

--- a/scripts/test_fullPipeline.sh
+++ b/scripts/test_fullPipeline.sh
@@ -5,7 +5,7 @@ YAML="${2:-example_params/fullPipeline.yml}"
 WORK="${3:-work}"
 make run_small_full_test WORK_DIR=${WORK} \
         PARAMS_FILE=$YAML \
-       	PROFILE="local" \
+       	PROFILE="standard" \
        	OPTIONS=" $OPTIONS " \
         ENTRY="wPipeline"
 

--- a/scripts/test_fullPipelineAggregate.sh
+++ b/scripts/test_fullPipelineAggregate.sh
@@ -5,7 +5,7 @@ YAML="${2:-example_params/fullPipelineAggregate.yml}"
 WORK="${3:-work}"
 make run_small_full_test WORK_DIR=${WORK} \
 	  PARAMS_FILE=$YAML \
-	  PROFILE="local" \
+	  PROFILE="standard" \
 	  OPTIONS=" $OPTIONS " \
 	  ENTRY="wAggregatePipeline"
 make check

--- a/scripts/test_fullPipelineS3Download.sh
+++ b/scripts/test_fullPipelineS3Download.sh
@@ -6,6 +6,6 @@ WORK="${3:-work}"
 make run_small_full_test \ 
 	WORK_DIR=${WORK} \
 	PARAMS_FILE=${YAML} \
-	PROFILE="local" \
+	PROFILE="standard" \
 	OPTIONS=" $OPTIONS "
 make check

--- a/scripts/test_magAttributes.sh
+++ b/scripts/test_magAttributes.sh
@@ -5,7 +5,7 @@ YAML="${2:-example_params/magAttributes.yml}"
 WORK="${3:-work}"
 make run_small_full_test \
 	WORK_DIR=${WORK} OPTIONS=" $OPTIONS " \
-       	PROFILE="local"  ENTRY="wMagAttributes" \
+       	PROFILE="standard"  ENTRY="wMagAttributes" \
 	PARAMS_FILE=$YAML
 
 make check

--- a/scripts/test_readMapping.sh
+++ b/scripts/test_readMapping.sh
@@ -5,7 +5,7 @@ YAML="${2:-example_params/readMapping.yml}"
 WORK="${3:-work}"
 make run_small_full_test \
 	WORK_DIR=${WORK} OPTIONS=" $OPTIONS " \
-       	PROFILE="local"  ENTRY="wReadMapping" \
+       	PROFILE="standard"  ENTRY="wReadMapping" \
 	PARAMS_FILE=$YAML
 
 make check


### PR DESCRIPTION
Currently a nextflow run fails if you do not provide the `-profile` parameter. This fix replaces the 'local' profile with nextflows 'standard' profile. Without providing the profile parameter, the standard profile is used.

thx @iXialumy 


## Please provide a description for this PR

Description goes here...

## PR review guidelines

Thank you for submitting this PR.

Before merge:

* The PR must be reviewed by one of the team members.

* Please check if anything in the Readme must be adjusted, or added (development-setup, production-setup, user-guide).

* PRs with new modules or workflow interfaces must include tests according to the developer [guidelines](https://github.com/pbelmann/meta-omics-toolkit#developer-guidelines).

* The new code is readable, well commented and should adhere to our developer [guidelines](https://github.com/pbelmann/meta-omics-toolkit#developer-guidelines).

* Before merging it must be checked if a squash of commits is required.






