### PR TITLE
No .command files in mag-attributes output fix

### DIFF
--- a/modules/magAttributes/module.nf
+++ b/modules/magAttributes/module.nf
@@ -36,7 +36,7 @@ process pCheckM {
     container "${params.checkm_image}"
 
     publishDir params.output, saveAs: { filename -> getOutput("${sample}", params.runid, "checkm", filename) }, \
-      pattern: "{**.tsv}"
+      pattern: "{**.tsv,**.out,**.err,**.log,**.sh}"
 
     when params.steps.containsKey("magAttributes") && params.steps.magAttributes.containsKey("checkm")
 
@@ -66,7 +66,7 @@ process pGtdbtk {
     label 'large'
 
     publishDir params.output, saveAs: { filename -> getOutput("${sample}",params.runid ,"gtdb", filename) }, \
-      pattern: "{**.tsv}"
+      pattern: "{**.tsv,**.out,**.err,**.log,**.sh}"
 
     when params.steps.containsKey("magAttributes") && params.steps.magAttributes.containsKey("gtdb")
 
@@ -97,7 +97,7 @@ process pProkka {
     time '5h'
 
     publishDir params.output, saveAs: { filename -> getOutput("${sample}",params.runid ,"prokka", filename) }, \
-      pattern: "{**.gff.gz,**.fna.gz,**.faa.gz,**.sqn.gz,**.txt,**.tsv,**.fsa.gz,**.ffn.gz,**.gbk.gz,**.tbl.gz}"
+      pattern: "{**.gff.gz,**.fna.gz,**.faa.gz,**.sqn.gz,**.txt,**.tsv,**.fsa.gz,**.ffn.gz,**.gbk.gz,**.tbl.gz,**.out,**.err,**.log,**.sh}"
 
     when params.steps.containsKey("magAttributes") && params.steps.magAttributes.containsKey("prokka")
 


### PR DESCRIPTION

## Please provide a description for this PR

PublishDir patterns are blocking `.command.*` files which are also needed in each output directory.

## PR review guidelines

Thank you for submitting this PR.

Before merge:

* The PR must be reviewed by one of the team members.

* Please check if anything in the Readme must be adjusted, or added (development-setup, production-setup, user-guide).

* PRs with new modules or workflow interfaces must include tests according to the developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* The new code is readable, well commented and should adhere to our developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* Before merging it must be checked if a squash of commits is required.






