### PR TITLE
fix(annotation): upgrade rgi and enable rgi heatmap

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -83,7 +83,7 @@ params {
    prodigal_image = "quay.io/biocontainers/prodigal:2.6.3--h779adbc_3"
    SCAPP_image = "quay.io/biocontainers/scapp:0.1.4--py_0"
    PlasClass_image = "quay.io/biocontainers/plasclass:0.1.1--pyhdfd78af_0"
-   rgi_image = "quay.io/biocontainers/rgi:5.2.1--pyhdfd78af_1"
+   rgi_image = "quay.io/biocontainers/rgi:6.0.1--pyha8f3691_1"
    sans_image = "quay.io/metagenomics/toolkit-sans:0.1.0"
    mmseqs2_image = "quay.io/microbiome-informatics/mmseqs:2.13"
 


### PR DESCRIPTION
This PR upgrades rgi to version 6.0.1 and adds a basic heatmap (#198 ). In case the heatmap is not useful, we can build
our own plot by using the csv file which is also exported.

## PR review guidelines

Thank you for submitting this PR.

Before merge:

* The PR must be reviewed by one of the team members.

* Please check if anything in the Readme must be adjusted, or added (development-setup, production-setup, user-guide).

* PRs with new modules or workflow interfaces must include tests according to the developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* The new code is readable, well commented and should adhere to our developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* Before merging it must be checked if a squash of commits is required.






