### PR TITLE
fix(pipeline): paths of not binned contigs are simplified

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -440,8 +440,10 @@ workflow wFullPipeline {
 
     ont.binsStats | mix(illumina.binsStats) | set { binsStats }
 
+    SAMPLE_IDX = 0
+    NOT_BINNED_PATH_IDX = 1
     ont.notBinnedContigs | mix(illumina.notBinnedContigs) 
-       | map { notBinned -> [ notBinned[0], "notBinned", notBinned[1]]} \
+       | map { notBinned -> [ notBinned[SAMPLE_IDX], notBinned[SAMPLE_IDX] + "_notBinned", notBinned[NOT_BINNED_PATH_IDX]]} \
        | set { notBinnedContigs }
 
     ont.binsStats | mix(illumina.binsStats) 
@@ -480,7 +482,6 @@ workflow wFullPipeline {
 
     wAnnotateUnbinnedList(Channel.value("unbinned"), Channel.value("meta"), notBinnedContigs, null, contigCoverage)
 
-    SAMPLE_IDX = 0
     BIN_ID_IDX = 1
     PATH_IDX = 2
     wAnnotateBinsList.out.proteins \

--- a/modules/annotation/module.nf
+++ b/modules/annotation/module.nf
@@ -221,11 +221,11 @@ process pResistanceGeneIdentifier {
       tuple val(sample), val(binID), file(fasta)
    
    output:
-      tuple val("${sample}"), val("${binID}"), path("${sample}_${binID}.rgi.tsv"), optional:true, emit: results
-      tuple val("${sample}"), val("${binID}"), path("${sample}_${binID}.rgi-1.csv"), optional:true, emit: resultsGenes
-      tuple val("${sample}"), val("${binID}"), path("${sample}_${binID}.rgi-1.eps"), \
+      tuple val("${sample}"), val("${binID}"), path("${binID}.rgi.tsv"), optional:true, emit: results
+      tuple val("${sample}"), val("${binID}"), path("${binID}.rgi-1.csv"), optional:true, emit: resultsGenes
+      tuple val("${sample}"), val("${binID}"), path("${binID}.rgi-1.eps"), \
 	path("${sample}_${binID}.rgi-1.png"), optional:true, emit: png
-      tuple val("${sample}_${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
+      tuple val("${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
         file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
    shell:
@@ -265,7 +265,7 @@ process pResistanceGeneIdentifier {
    zcat -f !{fasta} | sed 's/*//g' > input.faa
 
    mkdir output
-   OUTPUT_ID=!{sample}_!{binID}.rgi
+   OUTPUT_ID=!{binID}.rgi
    RGI_OUTPUT=output/${OUTPUT_ID}
    # load CARD database and run rgi
    rgi load --card_json ${CARD_JSON} --local
@@ -273,8 +273,8 @@ process pResistanceGeneIdentifier {
                --output_file ${RGI_OUTPUT} --input_type protein --local \
                --alignment_tool DIAMOND --num_threads !{task.cpus} --clean ${ADDITIONAL_RGI_PARAMS}
 
-   RGI_OUT_TMP=!{sample}_!{binID}.rgi.tmp.tsv
-   RGI_OUT=!{sample}_!{binID}.rgi.tsv
+   RGI_OUT_TMP=!{binID}.rgi.tmp.tsv
+   RGI_OUT=!{binID}.rgi.tsv
    # Produce files only if there is an actual output
    if [ $(tail -n +2 ${RGI_OUTPUT}.txt | wc -l) -gt 0 ]; then 
 
@@ -462,8 +462,8 @@ process pProkka {
       tuple val("${sample}"), val("${binID}"), file("*.tbl.gz"), emit: tbl 
       tuple val("${sample}"), val("${binID}"), file("*.sqn.gz"), emit: sqn 
       tuple val("${sample}"), val("${binID}"), file("*.txt"), emit: txt 
-      tuple val("${sample}"), val("${binID}"), file("${sample}_*_prokka.tsv"), emit: tsv 
-      tuple val("${sample}_${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
+      tuple val("${sample}"), val("${binID}"), file("*_prokka.tsv"), emit: tsv 
+      tuple val("${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
         file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
     shell:

--- a/modules/assembly/shortReadAssembler.nf
+++ b/modules/assembly/shortReadAssembler.nf
@@ -43,6 +43,7 @@ process pPredictFlavor {
     BASEPAIRS_COUNTER=$(zcat !{interleavedReads} !{unpairedReads} | seqkit stats -T | cut -d$'\t' -f 5 | tail -n 1)
     MODEL=!{baseDir}/models/assembler/megahit/default.pkl
     MEMORY=$(cli.py predict -m ${MODEL} -k !{kmerFrequencies} -b ${BASEPAIRS_COUNTER} -d !{nonpareilDiversity} -r ${READS_COUNTER})
+    echo -e "Memory: ${MEMORY}\nBasepairs: ${BASEPAIRS_COUNTER}\nReads: ${READS_COUNTER}" 
     '''
 }
 
@@ -89,11 +90,11 @@ process pMegahit {
 
     tag "Sample: $sample"
 
-    cpus { getNextHigherResource([-9, 137], task.exitStatus, "cpus", task.attempt, \
+    cpus { getNextHigherResource([-9, 137, 247], task.exitStatus, "cpus", task.attempt, \
 	"${memory}", params.steps.assembly.megahit, \
 	params.modules.assembly.process.pMegahit.defaults.flavor, "${sample}") }
 
-    memory { getNextHigherResource([-9, 137], task.exitStatus, "memory", task.attempt, \
+    memory { getNextHigherResource([-9, 137, 247], task.exitStatus, "memory", task.attempt, \
 	"${memory}", params.steps.assembly.megahit, \
 	params.modules.assembly.process.pMegahit.defaults.flavor, "${sample}") + ' GB' }
 

--- a/modules/binning/processes.nf
+++ b/modules/binning/processes.nf
@@ -110,11 +110,11 @@ process pCovermGenomeCoverage {
     run
 
     output:
-    tuple val("${sample}"), path("${sample}_out/mean.tsv"), emit: mean
-    tuple val("${sample}"), path("${sample}_out/trimmed_mean.tsv"), emit: trimmedMean
-    tuple val("${sample}"), path("${sample}_out/count.tsv"), emit: count
-    tuple val("${sample}"), path("${sample}_out/rpkm.tsv"), emit: rpkm
-    tuple val("${sample}"), path("${sample}_out/tpm.tsv"), emit: tpm
+    tuple val("${sample}"), path("${sample}_mean.tsv"), emit: mean
+    tuple val("${sample}"), path("${sample}_trimmed_mean.tsv"), emit: trimmedMean
+    tuple val("${sample}"), path("${sample}_count.tsv"), emit: count
+    tuple val("${sample}"), path("${sample}_rpkm.tsv"), emit: rpkm
+    tuple val("${sample}"), path("${sample}_tpm.tsv"), emit: tpm
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
     shell:

--- a/modules/plasmids/module.nf
+++ b/modules/plasmids/module.nf
@@ -77,9 +77,9 @@ process pPLSDB {
     tuple val(sample), val(binID), path(plasmids)
 
     output:
-    tuple val("${sample}"), val("${binID}"), path("${sample}_${binID}.tsv"), emit: allHits
-    tuple val("${sample}"), val("${binID}"), path("${sample}_${binID}_kmerThreshold_*.tsv"), emit: filteredHitsMetadata
-    tuple val("${sample}_${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
+    tuple val("${sample}"), val("${binID}"), path("${binID}.tsv"), emit: allHits
+    tuple val("${sample}"), val("${binID}"), path("${binID}_kmerThreshold_*.tsv"), emit: filteredHitsMetadata
+    tuple val("${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
         file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
     shell:
@@ -281,7 +281,7 @@ workflow _runCircularAnalysis {
        DO_NOT_ESTIMATE_IDENTITY = "-1"
 
        pSCAPP.out.plasmids \
-	| map { plasmids -> [plasmids[SAMPLE_IDX], "plasmid_assembly", plasmids[BIN_IDX]] } \
+	| map { plasmids -> [plasmids[SAMPLE_IDX], plasmids[SAMPLE_IDX] + "_plasmid_assembly", plasmids[BIN_IDX]] } \
 	| set { newPlasmids }
 
        newPlasmids | (pPlasClassCircular & _wRunMobTyper & pViralVerifyPlasmidCircular & pPlatonCircular)

--- a/modules/plasmids/processes.nf
+++ b/modules/plasmids/processes.nf
@@ -34,8 +34,8 @@ process pViralVerifyPlasmid {
     tuple val(sample), val(binID), path(plasmids)
 
     output:
-    tuple val("${sample}"), val("${binID}"), val("ViralVerifyPlasmid"), path("${sample}_${binID}_viralverifyplasmid.tsv"), emit: plasmidsStats, optional: true
-    tuple val("${sample}_${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
+    tuple val("${sample}"), val("${binID}"), val("ViralVerifyPlasmid"), path("${binID}_viralverifyplasmid.tsv"), emit: plasmidsStats, optional: true
+    tuple val("${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
       file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
 
@@ -81,7 +81,7 @@ process pViralVerifyPlasmid {
       # and add Sample and BinID
       sed  's/,/\t/g' *.csv \
 	| sed -E -n "1p;/${FILTER_STRING}/p" \
-        | sed -e '1 s/^[^\t]*\t/CONTIG\t/' -e '1 s/^/SAMPLE\tBIN_ID\t/g' -e "2,$ s/^/!{sample}\t!{binID}\t/g"  > !{sample}_!{binID}_viralverifyplasmid.tsv
+        | sed -e '1 s/^[^\t]*\t/CONTIG\t/' -e '1 s/^/SAMPLE\tBIN_ID\t/g' -e "2,$ s/^/!{sample}\t!{binID}\t/g" > !{binID}_viralverifyplasmid.tsv
     fi
     '''
 }
@@ -108,10 +108,10 @@ process pMobTyper {
     tuple val(sample), val(binID), path(plasmids), val(start), val(stop)
 
     output:
-    tuple val("${sample}_${binID}_chunk_${start}_${stop}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
+    tuple val("${binID}_chunk_${start}_${stop}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
       file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
     tuple val("${sample}"), val("${binID}"), val("MobTyper"), \
-	path("${sample}_${binID}_chunk_${start}_${stop}_mobtyper.tsv"), emit: plasmidsStats, optional: true
+	path("${binID}_chunk_${start}_${stop}_mobtyper.tsv"), emit: plasmidsStats, optional: true
 
     shell:
     EXTRACTED_DB=params.steps?.plasmid?.MobTyper?.database?.extractedDBPath ?: ""
@@ -142,8 +142,8 @@ process pPlasClass {
     tuple val(sample), val(binID), path(assembly)
 
     output:
-    tuple val("${sample}"), val("${binID}"), val("PlasClass"), path("${sample}_${binID}_plasclass.tsv"), emit: probabilities
-    tuple val("${sample}_${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
+    tuple val("${sample}"), val("${binID}"), val("PlasClass"), path("${binID}_plasclass.tsv"), emit: probabilities
+    tuple val("${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
         file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
     shell:
@@ -174,8 +174,8 @@ process pPlaton {
     tuple val(sample), val(binID), path(assembly)
 
     output:
-    tuple val("${sample}"), val("${binID}"), val("Platon"), path("${sample}_${binID}_platon.tsv"), optional: true, emit: plasmidsStats
-    tuple val("${sample}_${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
+    tuple val("${sample}"), val("${binID}"), val("Platon"), path("${binID}_platon.tsv"), optional: true, emit: plasmidsStats
+    tuple val("${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
       file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
     shell:
@@ -220,7 +220,7 @@ process pPlaton {
 
     if [ -n "$(find . -name '*.tsv')" ]; then
       # Add Sample and BinId
-      sed -e '1 s/^/SAMPLE\tBIN_ID\t/g' -e "1 s/\tID\t/\tCONTIG\t/"  -e "2,$ s/^/!{sample}\t!{binID}\t/g" *.tsv > !{sample}_!{binID}_platon.tsv
+      sed -e '1 s/^/SAMPLE\tBIN_ID\t/g' -e "1 s/\tID\t/\tCONTIG\t/"  -e "2,$ s/^/!{sample}\t!{binID}\t/g" *.tsv > !{binID}_platon.tsv
     fi
     '''
 }
@@ -243,9 +243,9 @@ process pFilter {
     tuple val(sample), val(binID), val(size), path(contigs), path(contigHeaderFiles)
 
     output:
-    tuple val("${sample}"), val("${binID}"), path("${sample}_${binID}_plasmids_filtered.fasta.gz"), emit: plasmids, optional: true
-    tuple val("${sample}"), val("${binID}"), path("${sample}_${binID}_plasmids_filtered.tsv"), emit: plasmidsTsv, optional: true
-    tuple val("${sample}_${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
+    tuple val("${sample}"), val("${binID}"), path("${binID}_filtered.fasta.gz"), emit: plasmids, optional: true
+    tuple val("${sample}"), val("${binID}"), path("${binID}_filtered.tsv"), emit: plasmidsTsv, optional: true
+    tuple val("${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
         file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
     shell:
@@ -258,8 +258,8 @@ process pFilter {
     	 csvtk cut -f CONTIG --tabs ${file} | tail -n +2 >> filtered_header.tsv
        done
 
-       PLASMID_OUT_FASTA=!{sample}_!{binID}_plasmids_filtered.fasta.gz 
-       PLASMID_OUT_TSV=!{sample}_!{binID}_plasmids_filtered.tsv
+       PLASMID_OUT_FASTA=!{binID}_filtered.fasta.gz 
+       PLASMID_OUT_TSV=!{binID}_filtered.tsv
 
        if [ -s filtered_header.tsv ]; then
          sort filtered_header.tsv | uniq > filtered_sorted_header.tsv

--- a/templates/coverm.sh
+++ b/templates/coverm.sh
@@ -1,19 +1,15 @@
-OUT=!{sample}_out
-mkdir $OUT
-
 readlink -f !{list_of_representatives} > list.txt 
 
 additionalParams=" !{percentIdentity} !{covermParams} " 
 covermCountParams=" --min-covered-fraction 0 "
 
 coverm genome -t !{task.cpus} ${additionalParams} -b !{mapping} \
-	--genome-fasta-list list.txt --methods mean --output-file $OUT/mean.tsv && sed -i '1 s| Mean$||' $OUT/mean.tsv  || true
+	--genome-fasta-list list.txt --methods mean --output-file !{sample}_mean.tsv && sed -i '1 s| Mean$||' !{sample}_mean.tsv  || true
 coverm genome -t !{task.cpus} ${additionalParams} -b !{mapping} \
-	--genome-fasta-list list.txt --methods trimmed_mean --output-file $OUT/trimmed_mean.tsv && sed -i '1 s| Trimmed Mean$||' $OUT/trimmed_mean.tsv || true
+	--genome-fasta-list list.txt --methods trimmed_mean --output-file !{sample}_trimmed_mean.tsv && sed -i '1 s| Trimmed Mean$||' !{sample}_trimmed_mean.tsv || true
 coverm genome -t !{task.cpus} -b !{mapping} ${covermCountParams} \
-	--genome-fasta-list list.txt --methods count  --output-file $OUT/count.tsv  && sed -i '1 s| Read Count$||' $OUT/count.tsv || true
+	--genome-fasta-list list.txt --methods count  --output-file !{sample}_count.tsv  && sed -i '1 s| Read Count$||' !{sample}_count.tsv || true
 coverm genome -t !{task.cpus} ${additionalParams} -b !{mapping} \
-	--genome-fasta-list list.txt  --methods rpkm  --output-file $OUT/rpkm.tsv  && sed -i '1 s| RPKM$||' $OUT/rpkm.tsv || true
+	--genome-fasta-list list.txt  --methods rpkm  --output-file !{sample}_rpkm.tsv  && sed -i '1 s| RPKM$||' !{sample}_rpkm.tsv || true
 coverm genome -t !{task.cpus} ${additionalParams} -b !{mapping} \
-	--genome-fasta-list list.txt --methods tpm --output-file $OUT/tpm.tsv && sed -i '1 s| TPM$||' $OUT/tpm.tsv || true
-
+	--genome-fasta-list list.txt --methods tpm --output-file !{sample}_tpm.tsv && sed -i '1 s| TPM$||' !{sample}_tpm.tsv || true

--- a/templates/filterAnd.sh
+++ b/templates/filterAnd.sh
@@ -2,8 +2,8 @@ for file in !{contigHeaderFiles}; do
 	csvtk cut -f CONTIG --tabs ${file} | tail -n +2 >> filtered_tools_header.tsv
 done
 
-PLASMID_OUT_FASTA=!{sample}_!{binID}_plasmids_filtered.fasta.gz 
-PLASMID_OUT_TSV=!{sample}_!{binID}_plasmids_filtered.tsv
+PLASMID_OUT_FASTA=!{binID}_filtered.fasta.gz 
+PLASMID_OUT_TSV=!{binID}_filtered.tsv
 
 if [ -s filtered_tools_header.tsv ]; then
 	sort filtered_tools_header.tsv <(seqkit fx2tab --name --only-id !{contigs}) \

--- a/templates/mobtyper.sh
+++ b/templates/mobtyper.sh
@@ -26,7 +26,7 @@ fi
 seqkit replace -p "\s.+" mobInput.fa \
 	| seqkit seq --min-len !{MIN_LENGTH} > unzipped_plasmids.fasta
 
-MOB_TYPER_OUT=!{sample}_!{binID}_chunk_!{start}_!{stop}_mobtyper.tsv
+MOB_TYPER_OUT=!{binID}_chunk_!{start}_!{stop}_mobtyper.tsv
 
 # Bug fix: Mob Typer does not search for the taxa.sqlite file in the user provided database directory
 sed -i " 178 i ETE3DBTAXAFILE = \"${MOB_TYPER_DB}/taxa.sqlite\"" /usr/local/lib/python3.8/dist-packages/mob_suite-3.1.0-py3.8.egg/mob_suite/constants.py

--- a/templates/plasClass.sh
+++ b/templates/plasClass.sh
@@ -1,7 +1,7 @@
 contigs="!{binID}_contigs.fa"
 PLASCLASS_OUT=out.tsv
 SEQUENCE_PROBABILITIES=sequence_length.tsv
-FINAL_OUTPUT=!{sample}_!{binID}_plasclass.tsv
+FINAL_OUTPUT=!{binID}_plasclass.tsv
 
 pigz  -f -d -c !{assembly} > ${contigs}
 classify_fasta.py -f ${contigs} -o ${SEQUENCE_PROBABILITIES} -p !{task.cpus} !{params.steps.plasmid.PlasClass.additionalParams}

--- a/templates/plsdb.sh
+++ b/templates/plsdb.sh
@@ -31,13 +31,13 @@ fi
 mash sketch -i !{params.steps.plasmid.PLSDB.additionalParams.mashSketch} -o query !{plasmids}
 
 # Compute distance between the query and plsdb plasmids
-mash dist ${PLSDB}/plsdb.msh query.msh -p !{task.cpus} !{params.steps.plasmid.PLSDB.additionalParams.mashDist} > !{sample}_!{binID}.tsv
+mash dist ${PLSDB}/plsdb.msh query.msh -p !{task.cpus} !{params.steps.plasmid.PLSDB.additionalParams.mashDist} > !{binID}.tsv
 
 # filter matches by user defined threshold
-sort -rgk 5,5 !{sample}_!{binID}.tsv | sed 's/\/.*$//g' \
+sort -rgk 5,5 !{binID}.tsv | sed 's/\/.*$//g' \
      | awk -v threshold=!{params.steps.plasmid.PLSDB.sharedKmerThreshold} '($5+0 > threshold) {print $0}' > matches.tsv
 
-OUTPUT=!{sample}_!{binID}_kmerThreshold_!{params.steps.plasmid.PLSDB.sharedKmerThreshold}.tsv
+OUTPUT=!{binID}_kmerThreshold_!{params.steps.plasmid.PLSDB.sharedKmerThreshold}.tsv
 
 # extract metadata of matches from plsdb
 while IFS=$"\t" read line ; do 

--- a/templates/prokka.sh
+++ b/templates/prokka.sh
@@ -1,7 +1,7 @@
 # Prepare Input Variables
 BIN=!{fasta}
 BIN_PREFIX=$(echo "${BIN%.*}")
-BIN_ID="$(basename !{fasta})"
+BIN_ID="!{binID}"
 
 # Run Prokka
 if [[ !{fasta} == *.gz ]]; then
@@ -22,7 +22,7 @@ gffread ${BIN_PREFIX}.gff --table @id,@geneid,@chr,@start,@end,@strand,@numexons
 # join prokka tsv output with the tsv version of the gff file for additional contig information.
 PROKKA_TMP_TSV=!{sample}_${BIN_ID}_prokka_tmp.tsv
 PROKKA_COV_TMP_TSV=!{sample}_${BIN_ID}_prokka_cov_tmp.tsv
-PROKKA_TSV=!{sample}_${BIN_ID}_prokka.tsv
+PROKKA_TSV=${BIN_ID}_prokka.tsv
 csvtk join -d$'\t' -T -f "locus_tag;ID" ${BIN_PREFIX}.tsv gff.tsv > ${PROKKA_TMP_TSV}
 
 # join prokka tsv with contig coverage tsv


### PR DESCRIPTION
Instead of a path like sample_sample_unbinned.tsv its now just sample_unbinned.tsv. 

## PR review guidelines

Thank you for submitting this PR.

Before merge:

* The PR must be reviewed by one of the team members.

* Please check if anything in the Readme must be adjusted, or added (development-setup, production-setup, user-guide).

* PRs with new modules or workflow interfaces must include tests according to the developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* The new code is readable, well commented and should adhere to our developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* Before merging it must be checked if a squash of commits is required.






