### PR TITLE
fix(annotation): do not run mmseqs on plasmids

### DIFF
--- a/modules/annotation/module.nf
+++ b/modules/annotation/module.nf
@@ -32,10 +32,11 @@ def constructParametersObject(String tool){
 * This function decides if the MMSeqs taxonomy process should be executed on MAGs.
 *
 */
-def runMMSeqsTaxonomy(isMMSeqsTaxonomySettingSet, isBinned, runOnBinned) {
-    // True if the MMSeqsTaxonomy setting is set and either the sample is not binned 
+def runMMSeqsTaxonomy(isMMSeqsTaxonomySettingSet, isBinned, isPlasmid, runOnBinned) {
+    // True if the MMSeqsTaxonomy setting is set and plasmids are not used as input and 
+    // either the sample is not binned 
     // or should explicitly run on binned samples 
-    return isMMSeqsTaxonomySettingSet && (!isBinned || runOnBinned)
+    return isMMSeqsTaxonomySettingSet && !isPlasmid && (!isBinned || runOnBinned)
 }
 
 
@@ -153,6 +154,7 @@ process pMMseqs2_taxonomy {
       when:
       runMMSeqsTaxonomy(params?.steps.containsKey("annotation") && params?.steps.annotation.containsKey("mmseqs2_taxonomy"), \
 	   binType.equals("binned"), \
+	   binType.equals("plasmid"), \
            params?.steps.containsKey("annotation") && params?.steps.annotation.containsKey("mmseqs2_taxonomy") && params?.steps.annotation.mmseqs2_taxonomy.runOnMAGs)
 
    input:


### PR DESCRIPTION
MMSeqs taxonomy should never run on plamids. In contrast to MAGs there is not even a parameter to enable it.

## PR review guidelines

Thank you for submitting this PR.

Before merge:

* The PR must be reviewed by one of the team members.

* Please check if anything in the Readme must be adjusted, or added (development-setup, production-setup, user-guide).

* PRs with new modules or workflow interfaces must include tests according to the developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* The new code is readable, well commented and should adhere to our developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* Before merging it must be checked if a squash of commits is required.






