### PR TITLE
fix(aggregation): separate listing calls when searching for files

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -145,10 +145,10 @@ def collectModuleFiles(dir, sra, modules){
    def fileList = [];
    def moduleList = []
    params.modules.eachWithIndex { v, k -> moduleList.add(v.getKey() + "/" + v.getValue().version.major + ".") }
-   def moduleDir = file(dir + "/" + module.name + "/")
 
    // iterate  over all specified modules
    for(module in modules){
+     def moduleDir = file(dir + "/" + module.name + "/")
      // Check if the module exists
      if(moduleDir.exists()){
        // collect all files


### PR DESCRIPTION
When we run the aggregation step, we need to list the available files of every sample directory.
The listing of different modules is now done in parallel. 

However, it can still be improved by running the listing for every dataset in parallel.

## PR review guidelines

Thank you for submitting this PR.

Before merge:

* The PR must be reviewed by one of the team members.

* Please check if anything in the Readme must be adjusted, or added (development-setup, production-setup, user-guide).

* PRs with new modules or workflow interfaces must include tests according to the developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* The new code is readable, well commented and should adhere to our developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* Before merging it must be checked if a squash of commits is required.






