### PR TITLE
feat(cooccurrence): compute p-values instead of plain correlation

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -94,7 +94,7 @@ params {
    samtools_image = "quay.io/biocontainers/samtools:1.14--hb421002_0"
    cmseq_image = "quay.io/metagenomics/toolkit-cmseq:0.1.0"
    metabinner_image = "quay.io/biocontainers/metabinner:1.4.2--hdfd78af_0"
-   cooccurrence_image = "quay.io/p_belmann/cooccurrence:0.5.0"
+   cooccurrence_image = "quay.io/p_belmann/cooccurrence:0.5.1"
    prodigal_image = "quay.io/biocontainers/prodigal:2.6.3--h779adbc_3"
    SCAPP_image = "quay.io/biocontainers/scapp:0.1.4--py_0"
    PlasClass_image = "quay.io/biocontainers/plasclass:0.1.1--pyhdfd78af_0"


### PR DESCRIPTION
This PR adds a correlation method for cooccurrence which 
   1. Creates multiple permutations of the initial abundance matrix
   2. Computes a spearman non-parametric rank correlation for every permutation. 
   3. Extracts p-values for every pair of MAGs 
   4. Corrects those p-values using Benjamini-Hochberg method.
   5. Only those correlations that were able to reject the null hypothesis (random/spurious association) are used.

## PR review guidelines

Thank you for submitting this PR.

Before merge:

* The PR must be reviewed by one of the team members.

* Please check if anything in the Readme must be adjusted, or added (development-setup, production-setup, user-guide).

* PRs with new modules or workflow interfaces must include tests according to the developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* The new code is readable, well commented and should adhere to our developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* Before merging it must be checked if a squash of commits is required.






