### PR TITLE
feature(annotation): Add GTDB MMesqs2-Taxonomy database

### DIFF
--- a/default/fullPipeline_illumina_nanpore.yml
+++ b/default/fullPipeline_illumina_nanpore.yml
@@ -273,14 +273,25 @@ steps:
         download:
           source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/card_20221209.tar.bz2
           md5sum: d7e627221a1d4584d1c1795cda774cdb
-#    mmseqs2_taxonomy:
-#      runOnMAGs: false
+    mmseqs2_taxonomy:
+      # Run taxonomy classification on MAGs and unbinable contigs or just the later
+      runOnMAGs: false
 #      ncbi_nr:
-#        params: ' --max-seqs 300 --max-accept 50 -c 0.8 --cov-mode 0 --start-sens 4 --sens-steps 1 -s 6 --num-iterations 2 -e 0.001 --e-profile 0.01 --db-load-mode 3 '
+#        params: ' --max-seqs 300 --max-accept 50 -c 0.8 --cov-mode 0 --start-sens 4 --sens-steps 1 -s 6 --num-iterations 2 -e 0.001 --e-profile 0.01 '
+#        ramMode: 'false'
 #        database:
 #          download:
 #            source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/nr_2022-04-02_mmseqs_taxonomy.tar.zst
 #            md5sum: 184bb8207ee1575cae7756137cde076b
+      gtdb:
+        # High sensitivity mode parameters only work for quality MAGs, for unbinable contigs use default parameters
+        params: '--max-seqs 300 --max-accept 50 -c 0.8 --cov-mode 0 --start-sens 4 --sens-steps 1 -s 6 --num-iterations 2 -e 0.001 --e-profile 0.01 '
+        # Load database into memory to speed up classification, only works if --db-load-mode 3 is set in params
+        ramMode: 'false'
+        database:
+          download:
+            source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/gtdb_r214_1_mmseqs.tar.gz
+            md5sum: 3c8f12c5c2dc55841a14dd30a0a4c718
     keggFromMMseqs2:
       database:
         download:

--- a/docs/modules/annotation.md
+++ b/docs/modules/annotation.md
@@ -33,7 +33,8 @@ MMseqs2 needs a combination of different data, index and dbtype files as "one" d
 See [MMseqs2 database](https://github.com/soedinglab/mmseqs2/wiki#mmseqs2-database-format) for more information.
 As multiple and in most cases, big files are used, tar and [zstd](https://github.com/facebook/zstd) are utilized to compress and transport files.
 Input databases have to be compressed by these and need to end with `.tar.zst`. Naming inside an archive is irrelevant, as databases are picked automatically.
-Multiple databases per one archive are not supported, one archive, one database.
+Multiple databases per one archive are not supported, one archive, one database. If the database also includes a taxonomy 
+as described [here](https://github.com/soedinglab/mmseqs2/wiki#creating-a-seqtaxdb), it can also be used for taxonomic classifications with MMseqs2 - Taxonomy.
 
 #### KEGGFromBlast
 KeGGFromBlast is only executed if genes are searched against a KEGG database. There must be a `kegg` identifier (see example configuration file) in the annotation section.

--- a/example_params/annotation.yml
+++ b/example_params/annotation.yml
@@ -41,6 +41,15 @@ steps:
             source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/card_20221209.tar.bz2
             md5sum: d7e627221a1d4584d1c1795cda774cdb
         additionalParams: ""
+      mmseqs2_taxonomy:
+        runOnMAGs: false
+        gtdb:
+          params: '-s 1 --orf-filter-s 1 -e 1e-15'
+          ramMode: 'false'
+          database:
+            download:
+              source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/gtdb_r214_1_mmseqs.tar.gz
+              md5sum: 3c8f12c5c2dc55841a14dd30a0a4c718
       prokka:
         prodigalMode: "meta"
         defaultKingdom: false

--- a/example_params/fullPipeline.yml
+++ b/example_params/fullPipeline.yml
@@ -201,15 +201,15 @@ steps:
     mmseqs2_taxonomy:
       runOnMAGs: true
       gtdb:
-        params: '-s 1 --max-seqs 100 --max-accept 50 --alignment-mode 1 --orf-filter-s 1 -e 1e-15 --db-load-mode 3'
-        ramMode: false
+        params: '-s 1 --orf-filter-s 1 -e 1e-15'
+        ramMode: 'false'
         database:
           download:
             source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/gtdb_r214_1_mmseqs.tar.gz
             md5sum: 3c8f12c5c2dc55841a14dd30a0a4c718
       ncbi_nr:
-        params: '-s 1 --max-seqs 100 --max-accept 50 --alignment-mode 1 --orf-filter-s 1 -e 1e-15 --db-load-mode 3'
-        ramMode: false
+        params: '-s 1 --orf-filter-s 1 -e 1e-15'
+        ramMode: 'false'
         database:
           download:
             source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/nr_2022-04-02_mmseqs_taxonomy.tar.zst

--- a/example_params/fullPipelineIlluminaOrONT.yml
+++ b/example_params/fullPipelineIlluminaOrONT.yml
@@ -171,14 +171,14 @@ steps:
       runOnMAGs: false
       gtdb:
         params: '-s 1 --orf-filter-s 1 -e 1e-15'
-        ramMode: false
+        ramMode: 'false'
         database:
           download:
             source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/gtdb_r214_1_mmseqs.tar.gz
             md5sum: 3c8f12c5c2dc55841a14dd30a0a4c718
       ncbi_nr:
         params: '-s 1 --orf-filter-s 1 -e 1e-15'
-        ramMode: false
+        ramMode: 'false'
         database:
           download:
             source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/nr_2022-04-02_mmseqs_taxonomy.tar.zst

--- a/example_params/fullPipelineONT.yml
+++ b/example_params/fullPipelineONT.yml
@@ -176,14 +176,14 @@ steps:
       runOnMAGs: false
       gtdb:
         params: '-s 1 --orf-filter-s 1 -e 1e-15'
-        ramMode: false
+        ramMode: 'false'
         database:
           download:
             source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/gtdb_r214_1_mmseqs.tar.gz
             md5sum: 3c8f12c5c2dc55841a14dd30a0a4c718
       ncbi_nr:
         params: '-s 1 --orf-filter-s 1 -e 1e-15'
-        ramMode: false
+        ramMode: 'false'
         database:
           download:
             source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/nr_2022-04-02_mmseqs_taxonomy.tar.zst

--- a/modules/annotation/module.nf
+++ b/modules/annotation/module.nf
@@ -74,7 +74,7 @@ process pMMseqs2 {
       tuple val(sample), file(fasta), file(contig2GeneMapping), val(dbType), val(parameters), val(EXTRACTED_DB), val(DOWNLOAD_LINK), val(MD5SUM), val(S5CMD_PARAMS)
    
    output:
-      tuple val("${dbType}"), val("${sample}"), val("${binType}"), path("${sample}_${binType}.${dbType}.blast.tsv"), emit: blast
+      tuple val("${dbType}"), val("${sample}"), val("${binType}"), path("${sample}_${binType}.${dbType}.blast.tsv"), optional:true, emit: blast
       tuple val("${sample}_${binType}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
         file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
@@ -229,7 +229,7 @@ process pMMseqs2_taxonomy {
     mkdir tmp
     # Only mmseqs2 databases can be used for every kind of search. Inputs have to be converted first.
     mmseqs createdb !{fasta} queryDB
-    // If the ramMode is set to true, the whole database will be loaded into the RAM. Don't forget to set the MMseqs2 parameter accordingly (--db-load-mode 3).
+    # If the ramMode is set to true, the whole database will be loaded into the RAM. Do not forget to set the MMseqs2 parameter accordingly, --db-load-mode 3.
     if !{ramMode}
     then
         # Load all indices into memory to increase searching speed


### PR DESCRIPTION

## Please provide a description for this PR

This PR adds the newest GTDB database as an additional database for MMseqs2-Taxonomy annotations.
Also a new flag to (not) use the MMseqs2-Taxonomy RAM mode is implemented.

## PR review guidelines

Thank you for submitting this PR.

Before merge:

* The PR must be reviewed by one of the team members.

* Please check if anything in the Readme must be adjusted, or added (development-setup, production-setup, user-guide).

* PRs with new modules or workflow interfaces must include tests according to the developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* The new code is readable, well commented and should adhere to our developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* Before merging it must be checked if a squash of commits is required.






