### PR TITLE
fix(annotation): mmseqs taxonomy sensitivity based on restry counter

### DIFF
--- a/default/fullPipeline_illumina_nanpore.yml
+++ b/default/fullPipeline_illumina_nanpore.yml
@@ -278,7 +278,7 @@ steps:
       runOnMAGs: true
       gtdb:
         # High sensitivity mode parameters only work for quality MAGs, for unbinable contigs use default parameters
-        params: ' --lca-ranks superkingdom,phylum,class,order,family,genus,species,subspecies --max-seqs 300 --max-accept 50 -c 0.8 --cov-mode 0 --start-sens 4 --sens-steps 1 -s 5 -e 0.001 --e-profile 0.01 '
+        params: ' --lca-ranks superkingdom,phylum,class,order,family,genus,species,subspecies --max-seqs 300 --max-accept 50 -c 0.8 --cov-mode 0 -e 0.001 --e-profile 0.01 '
         # Load database into memory to speed up classification, only works if --db-load-mode 3 is set in params
         ramMode: false
         database:

--- a/default/fullPipeline_illumina_nanpore_without_aggregate.yml
+++ b/default/fullPipeline_illumina_nanpore_without_aggregate.yml
@@ -179,7 +179,7 @@ steps:
       runOnMAGs: true
       gtdb:
         # High sensitivity mode parameters only work for quality MAGs, for unbinable contigs use default parameters
-        params: ' --lca-ranks superkingdom,phylum,class,order,family,genus,species,subspecies  --max-seqs 300 --max-accept 50 -c 0.8 --cov-mode 0 --start-sens 4 --sens-steps 1 -s 5 -e 0.001 --e-profile 0.01 '
+        params: ' --lca-ranks superkingdom,phylum,class,order,family,genus,species,subspecies  --max-seqs 300 --max-accept 50 -c 0.8 --cov-mode 0 -e 0.001 --e-profile 0.01 '
         # Load database into memory to speed up classification, only works if --db-load-mode 3 is set in params
         ramMode: false
         database:

--- a/example_params/annotation.yml
+++ b/example_params/annotation.yml
@@ -44,7 +44,7 @@ steps:
       mmseqs2_taxonomy:
         runOnMAGs: false
         gtdb:
-          params: '-s 1 --orf-filter-s 1 -e 1e-15'
+          params: ' --orf-filter-s 1 -e 1e-15'
           ramMode: false
           database:
             download:

--- a/example_params/fullPipeline.yml
+++ b/example_params/fullPipeline.yml
@@ -201,14 +201,14 @@ steps:
     mmseqs2_taxonomy:
       runOnMAGs: true
       gtdb:
-        params: '-s 1 --orf-filter-s 1 -e 1e-15'
+        params: ' --orf-filter-s 1 -e 1e-15'
         ramMode: false
         database:
           download:
             source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/gtdb_r214_1_mmseqs.tar.gz
             md5sum: 3c8f12c5c2dc55841a14dd30a0a4c718
       ncbi_nr:
-        params: '-s 1 --orf-filter-s 1 -e 1e-15'
+        params: ' --orf-filter-s 1 -e 1e-15'
         ramMode: false
         database:
           download:

--- a/example_params/fullPipelineIlluminaOrONT.yml
+++ b/example_params/fullPipelineIlluminaOrONT.yml
@@ -170,14 +170,14 @@ steps:
     mmseqs2_taxonomy:
       runOnMAGs: false
       gtdb:
-        params: '-s 1 --orf-filter-s 1 -e 1e-15'
+        params: ' --orf-filter-s 1 -e 1e-15'
         ramMode: false
         database:
           download:
             source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/gtdb_r214_1_mmseqs.tar.gz
             md5sum: 3c8f12c5c2dc55841a14dd30a0a4c718
       ncbi_nr:
-        params: '-s 1 --orf-filter-s 1 -e 1e-15'
+        params: ' --orf-filter-s 1 -e 1e-15'
         ramMode: false
         database:
           download:

--- a/example_params/fullPipelineONT.yml
+++ b/example_params/fullPipelineONT.yml
@@ -175,14 +175,14 @@ steps:
     mmseqs2_taxonomy:
       runOnMAGs: false
       gtdb:
-        params: '-s 1 --orf-filter-s 1 -e 1e-15'
+        params: ' --orf-filter-s 1 -e 1e-15'
         ramMode: false
         database:
           download:
             source: https://openstack.cebitec.uni-bielefeld.de:8080/databases/gtdb_r214_1_mmseqs.tar.gz
             md5sum: 3c8f12c5c2dc55841a14dd30a0a4c718
       ncbi_nr:
-        params: '-s 1 --orf-filter-s 1 -e 1e-15'
+        params: ' --orf-filter-s 1 -e 1e-15'
         ramMode: false
         database:
           download:


### PR DESCRIPTION
This PR introduces a fix for a bug which appears if mmseqs taxonomy is started with a high sensitivity value.
The parameters `--start-sens` and `--sens-steps ` are now hardcoded.

Before merge:

* The PR must be reviewed by one of the team members.

* Please check if anything in the Readme must be adjusted, or added (development-setup, production-setup, user-guide).

* PRs with new modules or workflow interfaces must include tests according to the developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* The new code is readable, well commented and should adhere to our developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* Before merging it must be checked if a squash of commits is required.






