### PR TITLE
fix(binning): metabinner should exit gracefully if not bins could be formed

### DIFF
--- a/templates/metabinner.sh
+++ b/templates/metabinner.sh
@@ -24,46 +24,55 @@ python /usr/local/bin/scripts/gen_kmer.py $CONTIGS $((MIN_LENGTH-1)) ${KMER_SIZE
 # fix shebang in all perl files
 sed -i '1 s/^.*$/#!\/usr\/bin\/env perl/' /usr/local/bin/auxiliary/*.pl
 
+function postProcess(){
+
+	# Create bins
+	METABINNER_RESULT=${RESULT}/metabinner_res/metabinner_result.tsv 
+	OLD_BINS=${TEMP_DIR}/old_bins
+	BIN_CONTIG_MAPPING=!{sample}_bin_contig_mapping.tsv
+	echo -e "BIN_ID\tCONTIG\tBINNER" > ${BIN_CONTIG_MAPPING}
+	mkdir ${OLD_BINS}
+
+	if [ -f "$METABINNER_RESULT" ]; then
+
+		for binId in $(cut -f 2 $METABINNER_RESULT | sort | uniq); do
+			# Create bins with the old header and the new header
+			BIN_NAME="!{sample}_bin.${binId}.fa"
+			OLD_BIN_NAME=${OLD_BINS}/"!{sample}_bin.${binId}.fa"
+			grep -e "$(printf '\t')${binId}$" $METABINNER_RESULT | cut -f 1 >> ${binId}.tsv 
+			seqkit grep --threads !{task.cpus} -f ${binId}.tsv $CONTIGS \
+				| seqkit replace -p "\s.+" > ${OLD_BIN_NAME}
+			seqkit replace  -p '(.*)' -r "\${1} MAG=${binId}" ${OLD_BIN_NAME} > ${BIN_NAME}
+
+			# Create bin to contig mapping and add the used binning tool to each line
+			grep ">" ${OLD_BIN_NAME} | sed 's/>//g' \
+				| sed "s/^/${BIN_NAME}\t/g;s/$/\tmetabinner/" >> ${BIN_CONTIG_MAPPING}
+		done
+	fi
+
+	# return not binned fasta files
+	BINNED_IDS=binned.tsv
+	NOT_BINNED=!{sample}_notBinned.fa
+	find . -maxdepth 1 -name "*.fa" -type f -exec grep -h ">" {} \; | tr -d ">" > ${BINNED_IDS}
+	if [ -s ${BINNED_IDS} ]; then
+       		# Get all not binned Ids
+        	seqkit grep -vf ${BINNED_IDS} !{contigs} \
+         	| seqkit replace  -p '(.*)' -r "\${1} MAG=NotBinned" > ${NOT_BINNED}
+	else
+        	seqkit replace  -p '(.*)' -r "\${1} MAG=NotBinned" !{contigs} > ${NOT_BINNED}
+	fi
+
+	# Quickfix
+	# Explanation: the metabinner biocontainer does contain perl scripts that use a hardcoded path to
+	# perl interpreter /usr/bin/perl which does not exist in the container. Thats why the container is 
+	# run as root and the permissions of all output files must be updated.
+	chown -R 1000:1000 .
+}
+
+
+trap 'if [[ $? == 1 && ! -s ${RESULT}/metabinner_res/metabinner_result.tsv ]]; then echo "Exit gracefully since no bins coult be constructed"; postProcess; exit 0; fi' EXIT
+
 # run metabinner
 bash /usr/local/bin/run_metabinner.sh -a $CONTIGS -o $RESULT -d $COVERAGE -k $(pwd)/*.csv -p /usr/local/bin -t !{task.cpus}
 
-# Create bins
-METABINNER_RESULT=${RESULT}/metabinner_res/metabinner_result.tsv 
-OLD_BINS=${TEMP_DIR}/old_bins
-BIN_CONTIG_MAPPING=!{sample}_bin_contig_mapping.tsv
-echo -e "BIN_ID\tCONTIG\tBINNER" > ${BIN_CONTIG_MAPPING}
-mkdir ${OLD_BINS}
-for binId in $(cut -f 2 $METABINNER_RESULT | sort | uniq); do
-
-	# Create bins with the old header and the new header
-	BIN_NAME="!{sample}_bin.${binId}.fa"
-	OLD_BIN_NAME=${OLD_BINS}/"!{sample}_bin.${binId}.fa"
-	grep -e "$(printf '\t')${binId}$" $METABINNER_RESULT | cut -f 1 >> ${binId}.tsv 
-	seqkit grep --threads !{task.cpus} -f ${binId}.tsv $CONTIGS \
-		| seqkit replace -p "\s.+" > ${OLD_BIN_NAME}
-	seqkit replace  -p '(.*)' -r "\${1} MAG=${binId}" ${OLD_BIN_NAME} > ${BIN_NAME}
-
-	# Create bin to contig mapping and add the used binning tool to each line
-	grep ">" ${OLD_BIN_NAME} | sed 's/>//g' \
-		| sed "s/^/${BIN_NAME}\t/g;s/$/\tmetabinner/" >> ${BIN_CONTIG_MAPPING}
-done
-
-
-# return not binned fasta files
-BINNED_IDS=binned.tsv
-NOT_BINNED=!{sample}_notBinned.fa
-grep -h ">" *.fa | tr -d ">" > ${BINNED_IDS}
-if [ -s ${BINNED_IDS} ]; then
-       # Get all not binned Ids
-        seqkit grep -vf ${BINNED_IDS} !{contigs} \
-         | seqkit replace  -p '(.*)' -r "\${1} MAG=NotBinned" > ${NOT_BINNED}
-else
-        seqkit replace  -p '(.*)' -r "\${1} MAG=NotBinned" !{contigs} > ${NOT_BINNED}
-fi
-
-
-# Quickfix
-# Explanation: the metabinner biocontainer does contain perl scripts that use a hardcoded path to
-# perl interpreter /usr/bin/perl which does not exist in the container. Thats why the container is 
-# run as root and the permissions of all output files must be updated.
-chown -R 1000:1000 .
+postProcess


### PR DESCRIPTION
Metabinner should not fail if no bins could be created.

## PR review guidelines

Thank you for submitting this PR.

Before merge:

* The PR must be reviewed by one of the team members.

* Please check if anything in the Readme must be adjusted, or added (development-setup, production-setup, user-guide).

* PRs with new modules or workflow interfaces must include tests according to the developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* The new code is readable, well commented and should adhere to our developer [guidelines](https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta-omics-toolkit/master.html#developer_guidelines).

* Before merging it must be checked if a squash of commits is required.






