### PR TITLE
feat(config):  provide function to dynamically assign resources based on number of attempts

### DIFF
--- a/docs/developer_guidelines.md
+++ b/docs/developer_guidelines.md
@@ -152,6 +152,25 @@ tuple env(FILE_ID), val("${output}"), val(params.LOG_LEVELS.INFO), file(".comman
         file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 ```
 
+
+### Resources
+
+Usually all processes get a label that is linked to the flavor provided in the resources section of the configuration file (e.g. `small`, `medium`, `large`).
+In cases where we can foresee that a processes might need more RAM depending on the size of the input data, it is also possible to use
+the getMemoryResources and getCPUsResources methods provided by the Utils class:
+
+Example:
+
+```
+memory { Utils.getMemoryResources(params.resources.small, "${sample}", task.attempt, params.resources) }
+
+cpus { Utils.getCPUsResources(params.resources.tiny.small, "${sample}", task.attempt, params.resources) }
+```
+
+One example where it might make sense to use this option is when a process uses `csvtk join` and uses per default a label with
+little RAM assigned.
+
+
 ### Time Limit
 
 Every process must define a time limit which will never be reached on "normal" execution. This limit is only useful for errors in the execution environment  

--- a/modules/annotation/module.nf
+++ b/modules/annotation/module.nf
@@ -649,7 +649,7 @@ process pCollectFile {
 
     memory { Utils.getMemoryResources(params.resources.small, "${sample}", task.attempt, params.resources) }
 
-    cpus { Utils.getCPUsResources(params.resources.tiny.small, "${sample}", task.attempt, params.resources) }
+    cpus { Utils.getCPUsResources(params.resources.small, "${sample}", task.attempt, params.resources) }
 
     tag "Sample: $sample, Database: $dbType"
 

--- a/modules/annotation/module.nf
+++ b/modules/annotation/module.nf
@@ -647,7 +647,9 @@ process pCount {
 **/
 process pCollectFile {
 
-    label 'highmemMedium'
+    memory { Utils.getMemoryResources(params.resources.small, "${sample}", task.attempt, params.resources) }
+
+    cpus { Utils.getCPUsResources(params.resources.tiny.small, "${sample}", task.attempt, params.resources) }
 
     tag "Sample: $sample, Database: $dbType"
 

--- a/modules/binning/processes.nf
+++ b/modules/binning/processes.nf
@@ -26,7 +26,9 @@ process pGetBinStatistics {
 
     publishDir params.output, mode: "${params.publishDirMode}", saveAs: { filename -> getOutput("${sample}", params.runid, "${module}", "${binner}", filename) }
 
-    label 'tiny'
+    memory { Utils.getMemoryResources(params.resources.tiny, "${sample}", task.attempt, params.resources) }
+
+    cpus { Utils.getCPUsResources(params.resources.tiny.tiny, "${sample}", task.attempt, params.resources) }
 
     input:
     val(module)

--- a/modules/binning/processes.nf
+++ b/modules/binning/processes.nf
@@ -28,7 +28,7 @@ process pGetBinStatistics {
 
     memory { Utils.getMemoryResources(params.resources.tiny, "${sample}", task.attempt, params.resources) }
 
-    cpus { Utils.getCPUsResources(params.resources.tiny.tiny, "${sample}", task.attempt, params.resources) }
+    cpus { Utils.getCPUsResources(params.resources.tiny, "${sample}", task.attempt, params.resources) }
 
     input:
     val(module)

--- a/scripts/test_quickstart.sh
+++ b/scripts/test_quickstart.sh
@@ -1,6 +1,6 @@
 # This file will be referenced on the online wiki
 
-git clone git@github.com:metagenomics/metagenomics-tk.git \
+git clone git@github.com:metagenomics/metagenomics-tk.git
 cd metagenomics-tk
 
 make nextflow


### PR DESCRIPTION
This PR allows to assign a new error handling strategy to selected processes.
Currently all processes, with the exception of Megahit, are simply retried with the same resources (CPUs, memory) assigned.
In cases where it can be foreseen that a process might need more RAM for bigger input data, the new strategy
can be assigned to the process to allow to increase the requested RAM value based on the number of execution attempts.

Development documentation has been extended regarding the usage of the new strategy.

This PR solves issue #355 

## PR review guidelines

Thank you for submitting this PR.

Before merge:

* A PR must be reviewed by one of the team members.

* Please check if anything in the documentation must be adjusted, or added (development-setup, production-setup, user-guide).

* PRs with new modules or workflow interfaces must include tests according to the developer [guidelines](https://metagenomics.github.io/metagenomics-tk/latest/developer_guidelines/).

* The new code is readable, well commented and should adhere to our developer [guidelines](https://metagenomics.github.io/metagenomics-tk/latest/developer_guidelines/).

* Before merging it must be checked if a squash of commits is required.




