### PR TITLE
Replaced shell with script for plasmids module

### DIFF
--- a/modules/plasmids/module.nf
+++ b/modules/plasmids/module.nf
@@ -51,9 +51,9 @@ process pSCAPP {
         file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
 
-    shell:
+    script:
     output = getOutput("${sample}", params.runid, "SCAPP", "")
-    template("scapp.sh")
+    template "scapp.sh"
 }
 
 
@@ -86,12 +86,12 @@ process pPLSDB {
     tuple val("${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
         file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
-    shell:
+    script:
     output = getOutput("${sample}", params.runid, "PLSDB", "")
     S5CMD_PARAMS=params.steps?.plasmid?.PLSDB?.database?.download?.s5cmd?.params ?: ""
     S3_PLSDB_ACCESS=params?.steps?.plasmid?.PLSDB?.database?.download?.s5cmd && S5CMD_PARAMS.indexOf("--no-sign-request") == -1 ? "\$S3_PLSDB_ACCESS" : ""
     S3_PLSDB_SECRET=params?.steps?.plasmid?.PLSDB?.database?.download?.s5cmd && S5CMD_PARAMS.indexOf("--no-sign-request") == -1 ? "\$S3_PLSDB_SECRET" : ""
-    template("plsdb.sh")
+    template "plsdb.sh"
 }
 
 
@@ -136,10 +136,10 @@ process pCount {
     output:
     tuple val("${sample}"), val("${binID}"), path(plasmids), env(COUNT) 
 
-    shell:
-    '''
-    COUNT=$(seqkit stats -T !{plasmids} | cut -d$'\t' -f 4 | tail -n 1)
-    '''
+    script:
+    """
+    COUNT=\$(seqkit stats -T ${plasmids} | cut -d\$'\t' -f 4 | tail -n 1)
+    """
 }
 
 
@@ -230,10 +230,10 @@ process pCollectFile {
     output:
     tuple val("${sample}"), val("${bin}"), val("${tool}"), path("*_toolOutputConcat_${tool}.tsv")
 
-    shell:
-    '''
-    csvtk -t -T concat !{toolOutputs} > !{sample}_!{bin}_toolOutputConcat_!{tool}.tsv
-    '''
+    script:
+    """
+    csvtk -t -T concat ${toolOutputs} > ${sample}_${bin}_toolOutputConcat_${tool}.tsv
+    """
 }
 
 /*

--- a/modules/plasmids/processes.nf
+++ b/modules/plasmids/processes.nf
@@ -40,7 +40,7 @@ process pViralVerifyPlasmid {
     tuple val("${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
       file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
-    shell:
+    script:
     EXTRACTED_DB=params.steps?.plasmid?.ViralVerifyPlasmid?.database?.extractedDBPath ?: ""
     DOWNLOAD_LINK=params.steps?.plasmid?.ViralVerifyPlasmid?.database?.download?.source ?: ""
     MD5SUM=params?.steps?.plasmid?.ViralVerifyPlasmid?.database?.download?.md5sum ?: ""
@@ -49,63 +49,63 @@ process pViralVerifyPlasmid {
     ADDITIONAL_PARAMS=params.steps?.plasmid?.ViralVerifyPlasmid?.additionalParams ?: ""
     S3_ViralVerifyPlasmid_ACCESS=params?.steps?.plasmid?.ViralVerifyPlasmid?.database?.download?.s5cmd && S5CMD_PARAMS.indexOf("--no-sign-request") == -1 ? "\$S3_ViralVerifyPlasmid_ACCESS" : ""
     S3_ViralVerifyPlasmid_SECRET=params?.steps?.plasmid?.ViralVerifyPlasmid?.database?.download?.s5cmd && S5CMD_PARAMS.indexOf("--no-sign-request") == -1 ? "\$S3_ViralVerifyPlasmid_SECRET" : ""
-    '''
-    FILTER_STRING="!{params.steps?.plasmid?.ViralVerifyPlasmid?.filterString}"
+    """
+    FILTER_STRING="${params.steps?.plasmid?.ViralVerifyPlasmid?.filterString}"
 
-    pigz -p !{task.cpus} -fdc !{plasmids} > unzipped.fasta
+    pigz -p ${task.cpus} -fdc ${plasmids} > unzipped.fasta
 
     PFAM_FILE=""
-    if [ -z "!{EXTRACTED_DB}" ]
+    if [ -z "${EXTRACTED_DB}" ]
     then
-         DATABASE=!{params.polished.databases}/pfam
-         LOCK_FILE=${DATABASE}/lock.txt
+         DATABASE=${params.polished.databases}/pfam
+         LOCK_FILE=\${DATABASE}/lock.txt
 
 	 # Check if access and secret keys are necessary for s5cmd
-         if [ ! -z "!{S3_ViralVerifyPlasmid_ACCESS}" ]
+         if [ ! -z "${S3_ViralVerifyPlasmid_ACCESS}" ]
          then
-             export AWS_ACCESS_KEY_ID=!{S3_ViralVerifyPlasmid_ACCESS}
-             export AWS_SECRET_ACCESS_KEY=!{S3_ViralVerifyPlasmid_SECRET}
+             export AWS_ACCESS_KEY_ID=${S3_ViralVerifyPlasmid_ACCESS}
+             export AWS_SECRET_ACCESS_KEY=${S3_ViralVerifyPlasmid_SECRET}
          fi
 
-         mkdir -p ${DATABASE}
-         flock ${LOCK_FILE} concurrentDownload.sh --output=${DATABASE} \
-            --link=!{DOWNLOAD_LINK} \
-            --httpsCommand="wgetStatic --no-check-certificate -qO- !{DOWNLOAD_LINK} | pigz -fdc > pfam.hmm " \
-            --s3FileCommand="s5cmd !{S5CMD_PARAMS} cat --concurrency !{task.cpus} !{DOWNLOAD_LINK} | pigz -fdc > pfam.hmm  " \
-            --s3DirectoryCommand="s5cmd !{S5CMD_PARAMS} cp --concurrency !{task.cpus} !{DOWNLOAD_LINK} . && mv * pfam.hmm " \
-            --s5cmdAdditionalParams="!{S5CMD_PARAMS}" \
-            --localCommand="gunzip -c !{DOWNLOAD_LINK} > ./pfam.hmm " \
-            --expectedMD5SUM=!{MD5SUM}
+         mkdir -p \${DATABASE}
+         flock \${LOCK_FILE} concurrentDownload.sh --output=\${DATABASE} \
+            --link=${DOWNLOAD_LINK} \
+            --httpsCommand="wgetStatic --no-check-certificate -qO- ${DOWNLOAD_LINK} | pigz -fdc > pfam.hmm " \
+            --s3FileCommand="s5cmd ${S5CMD_PARAMS} cat --concurrency ${task.cpus} ${DOWNLOAD_LINK} | pigz -fdc > pfam.hmm  " \
+            --s3DirectoryCommand="s5cmd ${S5CMD_PARAMS} cp --concurrency ${task.cpus} ${DOWNLOAD_LINK} . && mv * pfam.hmm " \
+            --s5cmdAdditionalParams="${S5CMD_PARAMS}" \
+            --localCommand="gunzip -c ${DOWNLOAD_LINK} > ./pfam.hmm " \
+            --expectedMD5SUM=${MD5SUM}
 
-          PFAM_FILE="${DATABASE}/out/pfam.hmm"
+          PFAM_FILE="\${DATABASE}/out/pfam.hmm"
     else
-          PFAM_FILE="!{EXTRACTED_DB}"
+          PFAM_FILE="${EXTRACTED_DB}"
     fi
 
     # ViralVerify should exit gracefully if the query sequence is too short for hmmsearch
-    trap 'if [[ $? == 1 && ! -s unzipped*proteins_circ.fa ]]; then echo "hmmsearch could not detect any protein"; exit 0; fi' EXIT
-    viralverify !{ADDITIONAL_PARAMS}  --hmm ${PFAM_FILE} -p -t !{task.cpus} -f unzipped.fasta -o .
+    trap 'if [[ \$? == 1 && ! -s unzipped*proteins_circ.fa ]]; then echo "hmmsearch could not detect any protein"; exit 0; fi' EXIT
+    viralverify ${ADDITIONAL_PARAMS}  --hmm \${PFAM_FILE} -p -t ${task.cpus} -f unzipped.fasta -o .
 
-    TMP_OUTPUT="!{binID}_viralverifyplasmid_tmp.tsv"
-    FINAL_OUTPUT="!{binID}_viralverifyplasmid.tsv"
+    TMP_OUTPUT="${binID}_viralverifyplasmid_tmp.tsv"
+    FINAL_OUTPUT="${binID}_viralverifyplasmid.tsv"
 
     # In case that no sequences could be found then at least an empty header file should be created
-    echo -e "CONTIG\tSAMPLE\tBIN_ID" > ${FINAL_OUTPUT} 
+    echo -e "CONTIG\tSAMPLE\tBIN_ID" > \${FINAL_OUTPUT} 
 
-    if [ -n "$(find . -name '*.csv')" ]; then
+    if [ -n "\$(find . -name '*.csv')" ]; then
       # Filter viral verify output by user provided strings 
       # and add Sample and BinID
       sed  's/,/\t/g' *.csv \
-	| sed -E -n "1p;/${FILTER_STRING}/p" \
-        | sed -e '1 s/^[^\t]*\t/CONTIG\t/' -e '1 s/^/SAMPLE\tBIN_ID\t/g' -e "2,$ s/^/!{sample}\t!{binID}\t/g" > ${TMP_OUTPUT}
-      if [ $(wc -l < ${TMP_OUTPUT}) -gt 1 ]; then
-        mv ${TMP_OUTPUT} ${FINAL_OUTPUT}
+	| sed -E -n "1p;/\${FILTER_STRING}/p" \
+        | sed -e '1 s/^[^\t]*\t/CONTIG\t/' -e '1 s/^/SAMPLE\tBIN_ID\t/g' -e "2,\$ s/^/${sample}\t${binID}\t/g" > \${TMP_OUTPUT}
+      if [ \$(wc -l < \${TMP_OUTPUT}) -gt 1 ]; then
+        mv \${TMP_OUTPUT} \${FINAL_OUTPUT}
       fi
     fi
 
     # Fix for ownership issue https://github.com/nextflow-io/nextflow/issues/4565
     chmod a+rw -R Prediction_results_fasta
-    '''
+    """
 }
 
 
@@ -137,7 +137,7 @@ process pMobTyper {
     tuple val("${sample}"), val("${binID}"), val("MobTyper"), \
 	path("${binID}_chunk_${start}_${stop}_mobtyper.tsv"), val("${chunkSize}"), emit: plasmidsStats, optional: true
 
-    shell:
+    script:
     EXTRACTED_DB=params.steps?.plasmid?.MobTyper?.database?.extractedDBPath ?: ""
     DOWNLOAD_LINK=params?.steps?.plasmid?.MobTyper?.database?.download?.source ?: ""
     MD5SUM=params?.steps?.plasmid?.MobTyper?.database?.download?.md5sum ?: ""
@@ -147,7 +147,7 @@ process pMobTyper {
     output = getOutput("${sample}", params.runid, "MobTyper", "")
     S3_MobTyper_ACCESS=params.steps?.plasmid?.MobTyper?.database?.download?.s5cmd && S5CMD_PARAMS.indexOf("--no-sign-request") == -1 ? "\$S3_MobTyper_ACCESS" : ""
     S3_MobTyper_SECRET=params.steps?.plasmid?.MobTyper?.database?.download?.s5cmd && S5CMD_PARAMS.indexOf("--no-sign-request") == -1 ? "\$S3_MobTyper_SECRET" : ""
-    template("mobtyper.sh")
+    template "mobtyper.sh"
 }
 
 
@@ -173,10 +173,10 @@ process pPlasClass {
     tuple val("${sample}"), val("${binID}"), val("PlasClass"), \
 	path("${binID}_chunk_${start}_${stop}_plasClass.tsv"), val("${chunkSize}"), emit: probabilities, optional: true
 
-    shell:
+    script:
     output = getOutput("${sample}", params.runid, "PlasClass", "")
     filter = params?.steps?.plasmid?.PlasClass?.threshold ? "TRUE" : ""
-    template("plasClass.sh")
+    template "plasClass.sh"
 }
 
 
@@ -206,7 +206,7 @@ process pPlaton {
     tuple val("${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
       file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
-    shell:
+    script:
     output = getOutput("${sample}", params.runid, "Platon", "")
     ADDITIONAL_PARAMS=params.steps?.plasmid?.Platon?.additionalParams ?: ""
     EXTRACTED_DB=params.steps?.plasmid?.Platon?.database?.extractedDBPath ?: ""
@@ -215,56 +215,56 @@ process pPlaton {
     S5CMD_PARAMS=params.steps?.plasmid?.Platon?.database?.download?.s5cmd?.params ?: ""
     S3_Platon_ACCESS=params.steps?.plasmid?.Platon?.database?.download?.s5cmd && S5CMD_PARAMS.indexOf("--no-sign-request") == -1 ? "\$S3_Platon_ACCESS" : ""
     S3_Platon_SECRET=params.steps?.plasmid?.Platon?.database?.download?.s5cmd && S5CMD_PARAMS.indexOf("--no-sign-request") == -1 ? "\$S3_Platon_SECRET" : ""
-    '''
+    """
     # --meta is not supported by Platon
     sed -i "458 i       '-p', 'meta', " /usr/local/lib/python3.9/site-packages/platon/functions.py
 
     # Check developer documentation
     PLATON_DB=""
-    if [ -z "!{EXTRACTED_DB}" ]
+    if [ -z "${EXTRACTED_DB}" ]
     then 
-      DATABASE=!{params.polished.databases}/platon
-      LOCK_FILE=${DATABASE}/checksum.txt
+      DATABASE=${params.polished.databases}/platon
+      LOCK_FILE=\${DATABASE}/checksum.txt
 
       # Check if access and secret keys are necessary for s5cmd
-      if [ ! -z "!{S3_Platon_ACCESS}" ]
+      if [ ! -z "${S3_Platon_ACCESS}" ]
       then
-          export AWS_ACCESS_KEY_ID=!{S3_Platon_ACCESS}
-          export AWS_SECRET_ACCESS_KEY=!{S3_Platon_SECRET}
+          export AWS_ACCESS_KEY_ID=${S3_Platon_ACCESS}
+          export AWS_SECRET_ACCESS_KEY=${S3_Platon_SECRET}
       fi
 
       # Download plsdb database if necessary
-      mkdir -p ${DATABASE}
-      flock ${LOCK_FILE} concurrentDownload.sh --output=${DATABASE} \
-	--link=!{DOWNLOAD_LINK} \
-	--httpsCommand="wgetStatic --no-check-certificate -qO- !{DOWNLOAD_LINK} | tar -xvz " \
-	--s3FileCommand="s5cmd !{S5CMD_PARAMS} cat !{DOWNLOAD_LINK} | tar -xvz  " \
-	--s3DirectoryCommand="mkdir db && cd db && s5cmd !{S5CMD_PARAMS} cp --concurrency !{task.cpus} !{DOWNLOAD_LINK} . " \
-	--s5cmdAdditionalParams="!{S5CMD_PARAMS}" \
-	--localCommand="tar xzvf !{DOWNLOAD_LINK} " \
-	--expectedMD5SUM=!{MD5SUM}
+      mkdir -p \${DATABASE}
+      flock \${LOCK_FILE} concurrentDownload.sh --output=\${DATABASE} \
+	--link=${DOWNLOAD_LINK} \
+	--httpsCommand="wgetStatic --no-check-certificate -qO- ${DOWNLOAD_LINK} | tar -xvz " \
+	--s3FileCommand="s5cmd ${S5CMD_PARAMS} cat ${DOWNLOAD_LINK} | tar -xvz  " \
+	--s3DirectoryCommand="mkdir db && cd db && s5cmd ${S5CMD_PARAMS} cp --concurrency ${task.cpus} ${DOWNLOAD_LINK} . " \
+	--s5cmdAdditionalParams="${S5CMD_PARAMS}" \
+	--localCommand="tar xzvf ${DOWNLOAD_LINK} " \
+	--expectedMD5SUM=${MD5SUM}
 
-      PLATON_DB=${DATABASE}/out/db
+      PLATON_DB=\${DATABASE}/out/db
     else
-      PLATON_DB=!{EXTRACTED_DB}
+      PLATON_DB=${EXTRACTED_DB}
     fi
 
-    FINAL_OUTPUT=!{binID}_platon.tsv
+    FINAL_OUTPUT=${binID}_platon.tsv
 
-    pigz -p !{task.cpus} -fdc !{assembly} > assembly.fasta
+    pigz -p ${task.cpus} -fdc ${assembly} > assembly.fasta
 
     # In some cases prodigal fails because of a too short query sequence. In such cases the process should end with exit code 0.
-    trap 'if [ "$?" == 1 ] && ( grep -q "ORFs failed" assembly.log || grep -q "ORFs=0$" assembly.log || grep -q "Error detecting input file format. First line seems to be blank." assembly.log ); then echo "Protein Prediction Failed"; exit 0; fi' EXIT
-    platon assembly.fasta !{ADDITIONAL_PARAMS} --db ${PLATON_DB} --mode sensitivity -t !{task.cpus}
+    trap 'if [ "\$?" == 1 ] && ( grep -q "ORFs failed" assembly.log || grep -q "ORFs=0\$" assembly.log || grep -q "Error detecting input file format. First line seems to be blank." assembly.log ); then echo "Protein Prediction Failed"; exit 0; fi' EXIT
+    platon assembly.fasta ${ADDITIONAL_PARAMS} --db \${PLATON_DB} --mode sensitivity -t ${task.cpus}
 
-    if [ -n "$(find . -name '*.tsv')" ]; then
+    if [ -n "\$(find . -name '*.tsv')" ]; then
       # Add Sample and BinId
-      sed -e '1 s/^/SAMPLE\tBIN_ID\t/g' -e "1 s/\tID\t/\tCONTIG\t/"  -e "2,$ s/^/!{sample}\t!{binID}\t/g" *.tsv > ${FINAL_OUTPUT}
+      sed -e '1 s/^/SAMPLE\tBIN_ID\t/g' -e "1 s/\tID\t/\tCONTIG\t/"  -e "2,\$ s/^/${sample}\t${binID}\t/g" *.tsv > \${FINAL_OUTPUT}
     else
       # In case that no sequences could be found then at least an empty header file should be created
-      echo -e "SAMPLE\tBIN_ID\tCONTIG" > ${FINAL_OUTPUT} 
+      echo -e "SAMPLE\tBIN_ID\tCONTIG" > \${FINAL_OUTPUT} 
     fi
-    '''
+    """
 }
 
 
@@ -291,72 +291,72 @@ process pFilter {
     tuple val("${binID}"), val("${output}"), val(params.LOG_LEVELS.INFO), file(".command.sh"), \
         file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
-    shell:
+    script:
     MIN_LENGTH=params.steps?.plasmid?.Filter?.minLength
     NUMBER_OF_CONTIGS=size+1
     switch(params.steps?.plasmid?.Filter.method) {
       case "OR":
-       '''
+       """
        mkdir header
        mkdir tmp
        mkdir missing
        mkdir input
 
-       for file in !{contigHeaderFiles}; do
-	  if [ $(wc -l < ${file}) -gt 1 ]; then
-            mv ${file} input/${file}
+       for file in ${contigHeaderFiles}; do
+	  if [ \$(wc -l < \${file}) -gt 1 ]; then
+            mv \${file} input/\${file}
           else
              # In case the detection tool could not find any plasmid it is labeled as missing
-             BASENAME=$(basename ${file})
-             METHOD="$(echo ${file} | rev | cut -d '_' -f 1 | rev | cut -d '.' -f 1)"
-             echo -e "CONTIG\t${METHOD}" > missing/${BASENAME}
+             BASENAME=\$(basename \${file})
+             METHOD="\$(echo \${file} | rev | cut -d '_' -f 1 | rev | cut -d '.' -f 1)"
+             echo -e "CONTIG\t\${METHOD}" > missing/\${BASENAME}
           fi
        done
 
-       for file in $(ls -1 input/*); do 
-         BASENAME=$(basename ${file})
-         TMP_FILE=tmp/${BASENAME}
-         FINAL_FILE=header/${BASENAME}
-         MISSING_FILE=missing/${BASENAME}
-         METHOD="$(echo ${file} | rev | cut -d '_' -f 1 | rev | cut -d '.' -f 1)"
-         csvtk cut -f CONTIG --tabs ${file} | sed -e "2,$ s/$/\tTRUE/g"  -e "1 s/$/\t${METHOD}/g" > ${TMP_FILE}
-	 csvtk cut -f CONTIG --tabs ${file} | tail -n +2 >> filtered_header.tsv
-         if [ $(wc -l < ${TMP_FILE}) -gt 1 ]; then
-                mv ${TMP_FILE} ${FINAL_FILE}
+       for file in \$(ls -1 input/*); do 
+         BASENAME=\$(basename \${file})
+         TMP_FILE=tmp/\${BASENAME}
+         FINAL_FILE=header/\${BASENAME}
+         MISSING_FILE=missing/\${BASENAME}
+         METHOD="\$(echo \${file} | rev | cut -d '_' -f 1 | rev | cut -d '.' -f 1)"
+         csvtk cut -f CONTIG --tabs \${file} | sed -e "2,\$ s/\$/\tTRUE/g"  -e "1 s/\$/\t\${METHOD}/g" > \${TMP_FILE}
+	 csvtk cut -f CONTIG --tabs \${file} | tail -n +2 >> filtered_header.tsv
+         if [ \$(wc -l < \${TMP_FILE}) -gt 1 ]; then
+                mv \${TMP_FILE} \${FINAL_FILE}
          else
-                mv ${TMP_FILE} ${MISSING_FILE}
+                mv \${TMP_FILE} \${MISSING_FILE}
          fi
        done
 
-       PLASMID_OUT_FASTA=!{binID}_filtered.fasta.gz 
-       PLASMID_OUT_TMP_FASTA=!{binID}_filtered.tmp.fasta.gz 
-       PLASMID_OUT_TSV=!{binID}_filtered.tsv
+       PLASMID_OUT_FASTA=${binID}_filtered.fasta.gz 
+       PLASMID_OUT_TMP_FASTA=${binID}_filtered.tmp.fasta.gz 
+       PLASMID_OUT_TSV=${binID}_filtered.tsv
 
        if [ -s filtered_header.tsv ]; then
          sort filtered_header.tsv | uniq > filtered_sorted_header.tsv
 
-         csvtk -t join -f 1 <(echo "CONTIG"; seqkit fx2tab --name --only-id !{contigs}) header/*  -k --na FALSE > !{binID}_detection_tools.tsv
+         csvtk -t join -f 1 <(echo "CONTIG"; seqkit fx2tab --name --only-id ${contigs}) header/*  -k --na FALSE > ${binID}_detection_tools.tsv
 
          # In case the detection tool could not find any plasmid it is labeled as missing
-         for file in $(ls -1 missing/*) ; do  
-            MISS_METHOD=$(csvtk cut -f -CONTIG --tabs $file);  
-            sed -i -e "2,$ s/$/\tFALSE/g" -e "1 s/$/\t${MISS_METHOD}/g" !{binID}_detection_tools.tsv
+         for file in \$(ls -1 missing/*) ; do  
+            MISS_METHOD=\$(csvtk cut -f -CONTIG --tabs \$file);  
+            sed -i -e "2,\$ s/\$/\tFALSE/g" -e "1 s/\$/\t\${MISS_METHOD}/g" ${binID}_detection_tools.tsv
          done
 
-         seqkit grep -f filtered_sorted_header.tsv !{contigs} | seqkit seq --min-len !{MIN_LENGTH} \
-         | pigz -c > ${PLASMID_OUT_TMP_FASTA}
+         seqkit grep -f filtered_sorted_header.tsv ${contigs} | seqkit seq --min-len ${MIN_LENGTH} \
+         | pigz -c > \${PLASMID_OUT_TMP_FASTA}
 
          # Output only fasta if it is not empty
-	 if ! [[ -z "$(zcat ${PLASMID_OUT_TMP_FASTA} | head -c 1)" ]]; then
-	     mv	${PLASMID_OUT_TMP_FASTA} ${PLASMID_OUT_FASTA}
-             seqkit fx2tab -H --length --only-id --gc --name ${PLASMID_OUT_FASTA} > ${PLASMID_OUT_TSV}
+	 if ! [[ -z "\$(zcat \${PLASMID_OUT_TMP_FASTA} | head -c 1)" ]]; then
+	     mv	\${PLASMID_OUT_TMP_FASTA} \${PLASMID_OUT_FASTA}
+             seqkit fx2tab -H --length --only-id --gc --name \${PLASMID_OUT_FASTA} > \${PLASMID_OUT_TSV}
          fi
 
        fi
-       '''
+       """
        break;
       case "AND":
-       template("filterAnd.sh")
+       template "filterAnd.sh"
        break;
     }
 }

--- a/templates/filterAnd.sh
+++ b/templates/filterAnd.sh
@@ -4,57 +4,57 @@ mkdir tmp
 mkdir missing
 mkdir input
 
-for file in !{contigHeaderFiles}; do
-  if [ $(wc -l < ${file}) -gt 1 ]; then
-     mv ${file} input/${file}
+for file in ${contigHeaderFiles}; do
+  if [ \$(wc -l < \${file}) -gt 1 ]; then
+     mv \${file} input/\${file}
   else
      # In case the detection tool could not find any plasmid it is labeled as missing
-     BASENAME=$(basename ${file})
-     METHOD="$(echo ${file} | rev | cut -d '_' -f 1 | rev | cut -d '.' -f 1)"
-     echo -e "CONTIG\t${METHOD}" > missing/${BASENAME}
+     BASENAME=\$(basename \${file})
+     METHOD="\$(echo \${file} | rev | cut -d '_' -f 1 | rev | cut -d '.' -f 1)"
+     echo -e "CONTIG\\t\${METHOD}" > missing/\${BASENAME}
   fi
 done
 
-for file in $(ls -1 input/*); do
-	BASENAME=$(basename ${file})
-        TMP_FILE=tmp/${BASENAME}
-        FINAL_FILE=header/${BASENAME}
-        MISSING_FILE=missing/${BASENAME}
-        METHOD="$(echo ${file} | rev | cut -d '_' -f 1 | rev | cut -d '.' -f 1)"
-	csvtk cut -f CONTIG --tabs ${file} | sed -e "2,$ s/$/\tTRUE/g"  -e "1 s/$/\t${METHOD}/g" > ${TMP_FILE}
-	csvtk cut -f CONTIG --tabs ${file} | tail -n +2 >> filtered_tools_header.tsv
-        if [ $(wc -l < ${TMP_FILE}) -gt 1 ]; then
-              mv ${TMP_FILE} ${FINAL_FILE}
+for file in \$(ls -1 input/*); do
+	BASENAME=\$(basename \${file})
+        TMP_FILE=tmp/\${BASENAME}
+        FINAL_FILE=header/\${BASENAME}
+        MISSING_FILE=missing/\${BASENAME}
+        METHOD="\$(echo \${file} | rev | cut -d '_' -f 1 | rev | cut -d '.' -f 1)"
+	csvtk cut -f CONTIG --tabs \${file} | sed -e "2,\$ s/\$/\\tTRUE/g"  -e "1 s/\$/\\t\${METHOD}/g" > \${TMP_FILE}
+	csvtk cut -f CONTIG --tabs \${file} | tail -n +2 >> filtered_tools_header.tsv
+        if [ \$(wc -l < \${TMP_FILE}) -gt 1 ]; then
+              mv \${TMP_FILE} \${FINAL_FILE}
         else
-              mv ${TMP_FILE} ${MISSING_FILE}
+              mv \${TMP_FILE} \${MISSING_FILE}
         fi
 done
 
-PLASMID_OUT_FASTA=!{binID}_filtered.fasta.gz 
-PLASMID_OUT_TSV=!{binID}_filtered.tsv
+PLASMID_OUT_FASTA=${binID}_filtered.fasta.gz 
+PLASMID_OUT_TSV=${binID}_filtered.tsv
 
 if [ -s filtered_tools_header.tsv ]; then
-	sort filtered_tools_header.tsv <(seqkit fx2tab --name --only-id !{contigs}) \
-	  | uniq -c | sed "s/^\ *//g" \
-	  | grep "^!{NUMBER_OF_CONTIGS} " \
+	sort filtered_tools_header.tsv <(seqkit fx2tab --name --only-id ${contigs}) \\
+	  | uniq -c | sed "s/^\\ *//g" \\
+	  | grep "^${NUMBER_OF_CONTIGS} " \\
 	  | cut -d ' ' -f 2- > filtered_selected_header.tsv
 
 	if [ -s filtered_selected_header.tsv ]; then
 
-	        csvtk -t join -f 1 <(echo "CONTIG"; seqkit fx2tab --name --only-id !{contigs}) header/*  -k --na FALSE > !{binID}_detection_tools.tsv
+	        csvtk -t join -f 1 <(echo "CONTIG"; seqkit fx2tab --name --only-id ${contigs}) header/*  -k --na FALSE > ${binID}_detection_tools.tsv
 
-		for file in $(ls -1 missing/*) ; do  
-                   MISS_METHOD=$(csvtk cut -f -CONTIG --tabs $file);  
-                   sed -i -e "2,$ s/$/\tFALSE/g" -e "1 s/$/\t${MISS_METHOD}/g" !{binID}_detection_tools.tsv
+		for file in \$(ls -1 missing/*) ; do  
+                   MISS_METHOD=\$(csvtk cut -f -CONTIG --tabs \$file);  
+                   sed -i -e "2,\$ s/\$/\\tFALSE/g" -e "1 s/\$/\\t\${MISS_METHOD}/g" ${binID}_detection_tools.tsv
                 done
 
-		seqkit grep -f filtered_selected_header.tsv !{contigs} \
-		 | seqkit seq --min-len !{MIN_LENGTH} \
-		 | pigz -c > ${PLASMID_OUT_FASTA}
+		seqkit grep -f filtered_selected_header.tsv ${contigs} \\
+		 | seqkit seq --min-len ${MIN_LENGTH} \\
+		 | pigz -c > \${PLASMID_OUT_FASTA}
 
-		if ! [[ -z "$(zcat ${PLASMID_OUT_TMP_FASTA} | head -c 1)" ]]; then
-	          mv ${PLASMID_OUT_TMP_FASTA} ${PLASMID_OUT_FASTA}
-                  seqkit fx2tab -H --length --only-id --gc --name ${PLASMID_OUT_FASTA} > ${PLASMID_OUT_TSV}
+		if ! [[ -z "\$(zcat \${PLASMID_OUT_TMP_FASTA} | head -c 1)" ]]; then
+	          mv \${PLASMID_OUT_TMP_FASTA} \${PLASMID_OUT_FASTA}
+                  seqkit fx2tab -H --length --only-id --gc --name \${PLASMID_OUT_FASTA} > \${PLASMID_OUT_TSV}
                 fi
 
 	fi

--- a/templates/mobtyper.sh
+++ b/templates/mobtyper.sh
@@ -1,42 +1,42 @@
 # Create new plasmid file
-seqkit range -r !{start}:!{stop} !{plasmids} > mobInput.fa
+seqkit range -r ${start}:${stop} ${plasmids} > mobInput.fa
 
 # Check developer documentation
 MOB_TYPER_DB=""
-if [ -z "!{EXTRACTED_DB}" ]
+if [ -z "${EXTRACTED_DB}" ]
 then
-   DATABASE=!{params.databases}/mob_typer
-   LOCK_FILE=${DATABASE}/checksum.txt
+   DATABASE=${params.databases}/mob_typer
+   LOCK_FILE=\${DATABASE}/checksum.txt
 
    # Check if access and secret keys are necessary for s5cmd
-   if [ ! -z "!{S3_MobTyper_ACCESS}" ]
+   if [ ! -z "${S3_MobTyper_ACCESS}" ]
    then
-        export AWS_ACCESS_KEY_ID=!{S3_MobTyper_ACCESS}
-        export AWS_SECRET_ACCESS_KEY=!{S3_MobTyper_SECRET}
+        export AWS_ACCESS_KEY_ID=${S3_MobTyper_ACCESS}
+        export AWS_SECRET_ACCESS_KEY=${S3_MobTyper_SECRET}
    fi
 
    # Download plsdb database if necessary
-   mkdir -p ${DATABASE}
-   flock ${LOCK_FILE} concurrentDownload.sh --output=${DATABASE} \
-    --link=!{DOWNLOAD_LINK} \
-    --httpsCommand=" wgetStatic --no-check-certificate -qO- !{DOWNLOAD_LINK} | tar --strip-components=1  -xvz " \
-    --s3FileCommand=" s5cmd !{S5CMD_PARAMS} cat !{DOWNLOAD_LINK} | tar --strip-components=1 -xvz " \
-    --s3DirectoryCommand=" s5cmd !{S5CMD_PARAMS} cp !{DOWNLOAD_LINK} . " \
-    --s5cmdAdditionalParams="!{S5CMD_PARAMS}" \
-    --localCommand="tar --strip-components=1  -xzvf !{DOWNLOAD_LINK} " \
-    --expectedMD5SUM=!{MD5SUM}
+   mkdir -p \${DATABASE}
+   flock \${LOCK_FILE} concurrentDownload.sh --output=\${DATABASE} \\
+    --link=${DOWNLOAD_LINK} \\
+    --httpsCommand=" wgetStatic --no-check-certificate -qO- ${DOWNLOAD_LINK} | tar --strip-components=1  -xvz " \\
+    --s3FileCommand=" s5cmd ${S5CMD_PARAMS} cat ${DOWNLOAD_LINK} | tar --strip-components=1 -xvz " \\
+    --s3DirectoryCommand=" s5cmd ${S5CMD_PARAMS} cp ${DOWNLOAD_LINK} . " \\
+    --s5cmdAdditionalParams="${S5CMD_PARAMS}" \\
+    --localCommand="tar --strip-components=1  -xzvf ${DOWNLOAD_LINK} " \\
+    --expectedMD5SUM=${MD5SUM}
 
-   MOB_TYPER_DB=${DATABASE}/out
+   MOB_TYPER_DB=\${DATABASE}/out
 else
-   MOB_TYPER_DB=!{EXTRACTED_DB}
+   MOB_TYPER_DB=${EXTRACTED_DB}
 fi
 
-seqkit replace -p "\s.+" mobInput.fa \
-	| seqkit seq --min-len !{MIN_LENGTH} > unzipped_plasmids.fasta
+seqkit replace -p "\\s.+" mobInput.fa \\
+	| seqkit seq --min-len ${MIN_LENGTH} > unzipped_plasmids.fasta
 
-MOB_TYPER_OUT=!{binID}_chunk_!{start}_!{stop}_mobtyper.tsv
+MOB_TYPER_OUT=${binID}_chunk_${start}_${stop}_mobtyper.tsv
 
-mob_typer !{ADDITIONAL_PARAMS} -d ${MOB_TYPER_DB} -n !{task.cpus} \
+mob_typer ${ADDITIONAL_PARAMS} -d \${MOB_TYPER_DB} -n ${task.cpus} \\
 	--multi --infile unzipped_plasmids.fasta --out_file out.tsv > >(tee -a mob_typer_stdout.log) 2> >(tee -a mob_typer_stderr.log >&2)
  
 # If there is not enough RAM on the host available, mobtyper exits with exit code 0 in some cases.
@@ -49,5 +49,5 @@ else
 fi
 
 # Add Sample and BinID
-sed  '1 s/^[^\t]*\t/CONTIG\t/' out.tsv \
-  | sed -e '1 s/^/SAMPLE\tBIN_ID\t/g' -e "2,$ s/^/!{sample}\t!{binID}\t/g" > ${MOB_TYPER_OUT}
+sed  '1 s/^[^\\t]*\\t/CONTIG\\t/' out.tsv \\
+  | sed -e '1 s/^/SAMPLE\\tBIN_ID\\t/g' -e "2,\$ s/^/${sample}\\t${binID}\\t/g" > \${MOB_TYPER_OUT}

--- a/templates/plasClass.sh
+++ b/templates/plasClass.sh
@@ -16,7 +16,7 @@ echo -e \${HEADER} > \${FINAL_OUTPUT}
 if [ -s \${SEQUENCE_PROBABILITIES} ]; then
   csvtk join --tabs --no-header-row  --fields "1" \${SEQUENCE_PROBABILITIES} \\
 	 <(seqkit fx2tab --length --only-id --name \${contigs} | sort -k 1,1) \\
-	| sed "s/\$/\\t${sample}\\t${binID}/g" >> \${PLASCLASS_OUT}
+	| sed "s|\$|\\t${sample}\\t${binID}|g" >> \${PLASCLASS_OUT}
 
   echo -e \${HEADER} > \${TMP_OUTPUT}
 

--- a/templates/plasClass.sh
+++ b/templates/plasClass.sh
@@ -1,31 +1,31 @@
-contigs="!{binID}_contigs.fa"
+contigs="${binID}_contigs.fa"
 PLASCLASS_OUT=out.tsv
 SEQUENCE_PROBABILITIES=sequence_length.tsv
-TMP_OUTPUT=!{binID}_plasclass_tmp.tsv
-FINAL_OUTPUT=!{binID}_chunk_!{start}_!{stop}_plasClass.tsv
+TMP_OUTPUT=${binID}_plasclass_tmp.tsv
+FINAL_OUTPUT=${binID}_chunk_${start}_${stop}_plasClass.tsv
 
-seqkit range -r !{start}:!{stop} !{assembly} > ${contigs}
+seqkit range -r ${start}:${stop} ${assembly} > \${contigs}
 
-classify_fasta.py -f ${contigs} -o ${SEQUENCE_PROBABILITIES} -p !{task.cpus} !{params.steps.plasmid.PlasClass.additionalParams}
+classify_fasta.py -f \${contigs} -o \${SEQUENCE_PROBABILITIES} -p ${task.cpus} ${params.steps.plasmid.PlasClass.additionalParams}
 
 # In case that no sequences could be found then at least an empty header file should be created
-HEADER="CONTIG\tPROBABILITY\tLENGTH\tSAMPLE\tBIN_ID"
-echo -e ${HEADER} > ${FINAL_OUTPUT}
+HEADER="CONTIG\\tPROBABILITY\\tLENGTH\\tSAMPLE\\tBIN_ID"
+echo -e \${HEADER} > \${FINAL_OUTPUT}
 
 # If sequences could be found then add additional information
-if [ -s ${SEQUENCE_PROBABILITIES} ]; then
-  csvtk join --tabs --no-header-row  --fields "1" ${SEQUENCE_PROBABILITIES} \
-	 <(seqkit fx2tab --length --only-id --name ${contigs} | sort -k 1,1) \
-	| sed "s/$/\t!{sample}\t!{binID}/g" >> ${PLASCLASS_OUT}
+if [ -s \${SEQUENCE_PROBABILITIES} ]; then
+  csvtk join --tabs --no-header-row  --fields "1" \${SEQUENCE_PROBABILITIES} \\
+	 <(seqkit fx2tab --length --only-id --name \${contigs} | sort -k 1,1) \\
+	| sed "s/\$/\\t${sample}\\t${binID}/g" >> \${PLASCLASS_OUT}
 
-  echo -e ${HEADER} > ${TMP_OUTPUT}
+  echo -e \${HEADER} > \${TMP_OUTPUT}
 
   # Filter the found sequences
-  tail -n +2 ${PLASCLASS_OUT} \
-        | awk -v threshold=!{params.steps.plasmid.PlasClass.threshold} '($2+0 > threshold) {print $0}' - >> ${TMP_OUTPUT}
+  tail -n +2 \${PLASCLASS_OUT} \\
+        | awk -v threshold=${params.steps.plasmid.PlasClass.threshold} '(\$2+0 > threshold) {print \$0}' - >> \${TMP_OUTPUT}
   
-  if [ $(wc -l < ${TMP_OUTPUT}) -gt 1 ]; then
-         mv ${TMP_OUTPUT} ${FINAL_OUTPUT}
+  if [ \$(wc -l < \${TMP_OUTPUT}) -gt 1 ]; then
+         mv \${TMP_OUTPUT} \${FINAL_OUTPUT}
   fi
 fi
 

--- a/templates/plsdb.sh
+++ b/templates/plsdb.sh
@@ -1,63 +1,63 @@
 
-EXTRACTED_DB="!{params.steps?.plasmid?.PLSDB?.database?.extractedDBPath}"
+EXTRACTED_DB="${params.steps?.plasmid?.PLSDB?.database?.extractedDBPath}"
 
 # Check developer documentation
 PLSDB=""
-if [[ $EXTRACTED_DB == "null" ]]
+if [[ \$EXTRACTED_DB == "null" ]]
 then 
-  DATABASE=!{params.databases}/plsdb
-  LOCK_FILE=${DATABASE}/checksum.txt
-  DOWNLOAD_LINK=!{params?.steps?.plasmid?.PLSDB?.database?.download?.source}
-  MD5SUM=!{params?.steps?.plasmid?.PLSDB?.database?.download?.md5sum}
+  DATABASE=${params.databases}/plsdb
+  LOCK_FILE=\${DATABASE}/checksum.txt
+  DOWNLOAD_LINK=${params?.steps?.plasmid?.PLSDB?.database?.download?.source}
+  MD5SUM=${params?.steps?.plasmid?.PLSDB?.database?.download?.md5sum}
 
   # Check if access and secret keys are necessary for s5cmd
-  if [ ! -z "!{S3_PLSDB_ACCESS}" ]
+  if [ ! -z "${S3_PLSDB_ACCESS}" ]
   then
-    export AWS_ACCESS_KEY_ID=!{S3_PLSDB_ACCESS}
-    export AWS_SECRET_ACCESS_KEY=!{S3_PLSDB_SECRET}
+    export AWS_ACCESS_KEY_ID=${S3_PLSDB_ACCESS}
+    export AWS_SECRET_ACCESS_KEY=${S3_PLSDB_SECRET}
   fi
 
   # Download plsdb database if necessary
-  mkdir -p ${DATABASE}
-  flock ${LOCK_FILE} concurrentDownload.sh --output=${DATABASE} \
-	--link=$DOWNLOAD_LINK \
-	--httpsCommand="wgetStatic --no-check-certificate -qO- $DOWNLOAD_LINK | tar xjv " \
-	--s3FileCommand="s5cmd !{S5CMD_PARAMS} cat --concurrency !{task.cpus} ${DOWNLOAD_LINK} |  tar xjv " \
-	--s3DirectoryCommand="s5cmd !{S5CMD_PARAMS} cp --concurrency !{task.cpus} ${DOWNLOAD_LINK} . " \
-	--s5cmdAdditionalParams="!{S5CMD_PARAMS}" \
-	--localCommand="tar xjvf ${DOWNLOAD_LINK} " \
-	--expectedMD5SUM=${MD5SUM}
+  mkdir -p \${DATABASE}
+  flock \${LOCK_FILE} concurrentDownload.sh --output=\${DATABASE} \\
+	--link=\$DOWNLOAD_LINK \\
+	--httpsCommand="wgetStatic --no-check-certificate -qO- \$DOWNLOAD_LINK | tar xjv " \\
+	--s3FileCommand="s5cmd ${S5CMD_PARAMS} cat --concurrency ${task.cpus} \${DOWNLOAD_LINK} |  tar xjv " \\
+	--s3DirectoryCommand="s5cmd ${S5CMD_PARAMS} cp --concurrency ${task.cpus} \${DOWNLOAD_LINK} . " \\
+	--s5cmdAdditionalParams="${S5CMD_PARAMS}" \\
+	--localCommand="tar xjvf \${DOWNLOAD_LINK} " \\
+	--expectedMD5SUM=\${MD5SUM}
 
-   PLSDB=${DATABASE}/out
+   PLSDB=\${DATABASE}/out
 else
-   PLSDB=${EXTRACTED_DB}
+   PLSDB=\${EXTRACTED_DB}
 fi
 
 # Sketch plasmids
-mash sketch -i !{params.steps.plasmid.PLSDB.additionalParams.mashSketch} -o query !{plasmids}
+mash sketch -i ${params.steps.plasmid.PLSDB.additionalParams.mashSketch} -o query ${plasmids}
 
 # Compute distance between the query and plsdb plasmids
-mash dist ${PLSDB}/plsdb.msh query.msh -p !{task.cpus} !{params.steps.plasmid.PLSDB.additionalParams.mashDist} > !{binID}.tsv
+mash dist \${PLSDB}/plsdb.msh query.msh -p ${task.cpus} ${params.steps.plasmid.PLSDB.additionalParams.mashDist} > ${binID}.tsv
 
 # filter matches by user defined threshold
 MATCHES_RAW=matches.tsv
-sort -rgk 5,5 !{binID}.tsv | sed 's/\/.*$//g' \
-     | awk -v threshold=!{params.steps.plasmid.PLSDB.sharedKmerThreshold} '($5+0 > threshold) {print $0}' > ${MATCHES_RAW}
+sort -rgk 5,5 ${binID}.tsv | sed 's/\\/.*\$//g' \\
+     | awk -v threshold=${params.steps.plasmid.PLSDB.sharedKmerThreshold} '(\$5+0 > threshold) {print \$0}' > \${MATCHES_RAW}
 
-OUTPUT=!{binID}_kmerThreshold_!{params.steps.plasmid.PLSDB.sharedKmerThreshold}.tsv
+OUTPUT=${binID}_kmerThreshold_${params.steps.plasmid.PLSDB.sharedKmerThreshold}.tsv
 
 # extract metadata of matches from plsdb
 MATCHES_CONTENT=matches_detailed.tsv
-while IFS=$"\t" read line ; do 
-	hit=$(echo "$line" | cut -f 1); 
-	grep -F -w $hit ${PLSDB}/plsdb.tsv \
-		| sed "s/^/${line}\t/g" \
-		| sed "s/^/!{sample}\t!{binID}\t/g" ; 
-done <${MATCHES_RAW} > ${MATCHES_CONTENT}
+while IFS=\$"\\t" read line ; do 
+	hit=\$(echo "\$line" | cut -f 1); 
+	grep -F -w \$hit \${PLSDB}/plsdb.tsv \\
+		| sed "s/^/\${line}\\t/g" \\
+		| sed "s/^/${sample}\\t${binID}\\t/g" ; 
+done <\${MATCHES_RAW} > \${MATCHES_CONTENT}
 
-if [ -s ${MATCHES_CONTENT} ]; then
+if [ -s \${MATCHES_CONTENT} ]; then
   # add mash query, reference, p-value and distance fields
-  cat <(head -n 1 ${PLSDB}/plsdb.tsv \
-	| sed "s/^/MASH_REFERENCE\tMASH_QUERY\tMASH_DISTANCE\tMASH_P_VALUE\tMASH_MATCHING_HASHES\t/g"  \
-	| sed 's/^/SAMPLE\tBIN_ID\t/g') ${MATCHES_CONTENT} > ${OUTPUT}
+  cat <(head -n 1 \${PLSDB}/plsdb.tsv \\
+	| sed "s/^/MASH_REFERENCE\\tMASH_QUERY\\tMASH_DISTANCE\\tMASH_P_VALUE\\tMASH_MATCHING_HASHES\\t/g"  \\
+	| sed 's/^/SAMPLE\\tBIN_ID\\t/g') \${MATCHES_CONTENT} > \${OUTPUT}
 fi

--- a/templates/scapp.sh
+++ b/templates/scapp.sh
@@ -1,33 +1,33 @@
-PLASMIDS_OUTPUT=!{sample}_plasmids.fasta.gz
-HEADER_MAPPING_OUTPUT=!{sample}_plasmids_header_mapping.tsv
+PLASMIDS_OUTPUT=${sample}_plasmids.fasta.gz
+HEADER_MAPPING_OUTPUT=${sample}_plasmids_header_mapping.tsv
 
-GRAPH_FILE_PATH=$(readlink -f !{assemblyGraph})
+GRAPH_FILE_PATH=\$(readlink -f ${assemblyGraph})
 
-if [[ $GRAPH_FILE_PATH == *.gfa ]]
+if [[ \$GRAPH_FILE_PATH == *.gfa ]]
 then
 	GRAPH=out.fastg
-	python3 $(which metaflye_gfa2fastg.py) $GRAPH_FILE_PATH $GRAPH
+	python3 \$(which metaflye_gfa2fastg.py) \$GRAPH_FILE_PATH \$GRAPH
 else
-	GRAPH=!{assemblyGraph}
+	GRAPH=${assemblyGraph}
 fi
 
 # Make sure that exit code 1 is also accepted due to known SCAPP bug:
 # https://github.com/Shamir-Lab/SCAPP/issues/26
-trap 'if [[ $? == 1 ]]; then echo "No plasmid could be detected"; exit 0; fi' EXIT
+trap 'if [[ \$? == 1 ]]; then echo "No plasmid could be detected"; exit 0; fi' EXIT
 
-scapp -g ${GRAPH} -k !{maxKmer} -p !{task.cpus} !{params.steps.plasmid.SCAPP.additionalParams.SCAPP} -b !{bam} -o .
+scapp -g \${GRAPH} -k ${maxKmer} -p ${task.cpus} ${params.steps.plasmid.SCAPP.additionalParams.SCAPP} -b ${bam} -o .
 
 if [ -s *.confident_cycs.fasta ]; then
   # The following function modifies the assembly fasta headers according to the pattern: SAMPLEID_SEQUENCECOUNTER_SEQUENCEHASH
-  transform.sh "$(ls -1 *.confident_cycs.fasta)" ${PLASMIDS_OUTPUT} ${HEADER_MAPPING_OUTPUT} !{sample} !{task.cpus}
+  transform.sh "\$(ls -1 *.confident_cycs.fasta)" \${PLASMIDS_OUTPUT} \${HEADER_MAPPING_OUTPUT} ${sample} ${task.cpus}
 
-  PLASMID_STATS=!{sample}_plasmids_stats.tsv
-  PLASMID_SUMMARY_STATS=!{sample}_plasmids_summary_stats.tsv
+  PLASMID_STATS=${sample}_plasmids_stats.tsv
+  PLASMID_SUMMARY_STATS=${sample}_plasmids_summary_stats.tsv
   # get basic contig stats
-  csvtk concat --out-tabs -H <(csvtk transpose <(echo -e "SAMPLE\n!{sample}") ) <(csvtk transpose  <(seqkit stat -Ta ${PLASMIDS_OUTPUT}) ) \
-	        | csvtk --tabs transpose | sed 's/"//g' > ${PLASMID_SUMMARY_STATS}
+  csvtk concat --out-tabs -H <(csvtk transpose <(echo -e "SAMPLE\\n${sample}") ) <(csvtk transpose  <(seqkit stat -Ta \${PLASMIDS_OUTPUT}) ) \\
+	        | csvtk --tabs transpose | sed 's/"//g' > \${PLASMID_SUMMARY_STATS}
 
-  echo -e "SAMPLE\tID\tLENGTH\tGC" > ${PLASMID_STATS}
-  seqkit fx2tab -l -g -n -i  ${PLASMIDS_OUTPUT} \
-	| sed "s/^/!{sample}\t/g"  >> ${PLASMID_STATS} 
+  echo -e "SAMPLE\\tID\\tLENGTH\\tGC" > \${PLASMID_STATS}
+  seqkit fx2tab -l -g -n -i  \${PLASMIDS_OUTPUT} \\
+	| sed "s/^/${sample}\\t/g"  >> \${PLASMID_STATS} 
 fi


### PR DESCRIPTION
Replaced shell with script for plasmids module referring #394

- Refactored `shell` section to `script` section
- Refactored `'''` to `"""` where needed due to nextflow and bash variable substitution restrictions
- Escaped `\` to `\\` in templates, this is not needed for triple quote sections
- Escaped `$` to `\$` in templates and triple quote sections, as these will be bash variable substitutions
- Refactored `sed` delimiter from `/` to `|` where it is preceded with a `$` as groovy has `$/` reserved for slashy-strings
- Refactored `!{variable}` to `${variable}`, as these are nextflow variable substitutions