### PR TITLE
Replaced shell with script for binning module

### DIFF
--- a/modules/binning/ontBinning.nf
+++ b/modules/binning/ontBinning.nf
@@ -35,7 +35,7 @@ process pGetMappingQuality {
     tuple val("${sample}"), file("${sample}_flagstat_failed.tsv"), emit: flagstatFailed
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
+    script:
     template 'mapping_quality.sh'
 }
 
@@ -69,7 +69,7 @@ process pMetaCoAG {
     tuple val("${sample}"), file("${sample}_bin_contig_mapping.tsv"), optional: true, emit: binContigMapping
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
+    script:
     template "metacoag.sh"
 }
 

--- a/modules/binning/processes.nf
+++ b/modules/binning/processes.nf
@@ -39,7 +39,7 @@ process pGetBinStatistics {
     tuple val("${sample}"), file("${sample}_bins_stats.tsv"), optional: true, emit: binsStats
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
+    script:
     DO_NOT_ESTIMATE_QUALITY = -1 
     MEDIAN_QUALITY=Double.parseDouble(medianQuality)
     percentIdentity = MEDIAN_QUALITY != DO_NOT_ESTIMATE_QUALITY ? \
@@ -72,24 +72,24 @@ process pCovermContigsCoverage {
     tuple val("${sample}"), path("${sample}_metabat_coverm_coverage.tsv"), emit: metabat_coverage, optional: true
     tuple file(".command.out"), file(".command.err"), file(".command.log"), file(".command.sh"), emit: logs
 
-    shell:
+    script:
     DO_NOT_ESTIMATE_QUALITY = -1 
     MEDIAN_QUALITY=Double.parseDouble(medianQuality)
     percentIdentity = MEDIAN_QUALITY != DO_NOT_ESTIMATE_QUALITY ? \
 	" --min-read-percent-identity "+Utils.getMappingIdentityParam(MEDIAN_QUALITY) : " "
-    '''
-    coverm contig --threads !{task.cpus} \
-	--bam-files !{bamFile} !{covermParams} !{percentIdentity} \
+    """
+    coverm contig --threads ${task.cpus} \
+	--bam-files ${bamFile} ${covermParams} ${percentIdentity} \
 	--methods mean trimmed_mean variance length count reads_per_base rpkm tpm \
-	| sed '1 s/^.*$/SAMPLE\tCONTIG\tMEAN_CONTIG\tTRIMMED_MEAN_CONTIG\tVARIANCE_CONTIG\tLENGTH_CONTIG\tREAD_COUNT_CONTIG\tREADS_PER_BASE_CONTIG\tRPKM_CONTIG\tTPM_CONTIG/g' \
-	| sed "2,$ s/^/!{sample}\t/g" > !{sample}_default_coverm_coverage.tsv
+	| sed '1 s/^.*\$/SAMPLE\tCONTIG\tMEAN_CONTIG\tTRIMMED_MEAN_CONTIG\tVARIANCE_CONTIG\tLENGTH_CONTIG\tREAD_COUNT_CONTIG\tREADS_PER_BASE_CONTIG\tRPKM_CONTIG\tTPM_CONTIG/g' \
+	| sed "2,\$ s/^/${sample}\t/g" > ${sample}_default_coverm_coverage.tsv
 
-    coverm contig --threads !{task.cpus} \
-	--bam-files !{bamFile} !{covermParams} !{percentIdentity} \
+    coverm contig --threads ${task.cpus} \
+	--bam-files ${bamFile} ${covermParams} ${percentIdentity} \
         --methods metabat \
-	| sed '1 s/^.*$/SAMPLE\tCONTIG_NAME\tMETABAT_CONTIG_LENGTH\tMETABAT_TOTAL_AVG_DEPTH_CONTIG\tMETABAT_BAM_CONTIG\tMETABAT_VARIANCE_CONTIG/g' \
-	| sed "2,$ s/^/!{sample}\t/g" > !{sample}_metabat_coverm_coverage.tsv
-    '''
+	| sed '1 s/^.*\$/SAMPLE\tCONTIG_NAME\tMETABAT_CONTIG_LENGTH\tMETABAT_TOTAL_AVG_DEPTH_CONTIG\tMETABAT_BAM_CONTIG\tMETABAT_VARIANCE_CONTIG/g' \
+	| sed "2,\$ s/^/${sample}\t/g" > ${sample}_metabat_coverm_coverage.tsv
+    """
 }
 
 
@@ -124,14 +124,14 @@ process pCovermGenomeCoverage {
 	val(params.LOG_LEVELS.INFO), file(".command.sh"), \
 	file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
-    shell:
+    script:
     DO_NOT_ESTIMATE_QUALITY = -1 
     MEDIAN_QUALITY=Double.parseDouble(medianQuality)
     percentIdentity = MEDIAN_QUALITY != DO_NOT_ESTIMATE_QUALITY ? \
 	" --min-read-percent-identity "+Utils.getMappingIdentityParam(MEDIAN_QUALITY) : " "
     prefixOutput = prefix.trim() ? prefix : sample
     output = getOutput(prefixOutput, params.runid, module, outputToolDir, "")
-    template('coverm.sh')
+    template 'coverm.sh'
 }
 
 
@@ -161,18 +161,18 @@ process pMinimap2 {
     tuple val("${sample}"), file("${sample}_unmapped.fq.gz"), optional: true, emit: unmappedReads
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
+    script:
     getUnmapped = getUnmapped ? "TRUE" : ""
-    '''
-    minimap2 -t !{task.cpus} !{minimapParams} -ax map-ont !{contigs} reads.fq.gz \
-             | samtools view !{samtoolsViewParams} --threads !{task.cpus} -bS - \
-             | samtools sort -l 9 --threads !{task.cpus} - > !{sample}.bam
+    """
+    minimap2 -t ${task.cpus} ${minimapParams} -ax map-ont ${contigs} reads.fq.gz \
+             | samtools view ${samtoolsViewParams} --threads ${task.cpus} -bS - \
+             | samtools sort -l 9 --threads ${task.cpus} - > ${sample}.bam
 
     # If Fragment Recruitment is selected then reads that could not be mapped should be returned
-    if [[ "!{getUnmapped}" == "TRUE" ]]; then
-        samtools bam2fq -f 4 !{sample}.bam | pigz --best --processes !{task.cpus} > !{sample}_unmapped.fq.gz
+    if [[ "${getUnmapped}" == "TRUE" ]]; then
+        samtools bam2fq -f 4 ${sample}.bam | pigz --best --processes ${task.cpus} > ${sample}_unmapped.fq.gz
     fi
-    '''
+    """
 }
 
 
@@ -204,24 +204,24 @@ process pBowtie2 {
     tuple val("${sample}"), file("${sample}_bowtie_stats.txt"), optional: true, emit: stats
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
+    script:
     getUnmapped = getUnmapped ? "TRUE" : ""
-    '''
-    INDEX=!{sample}.index
+    """
+    INDEX=${sample}.index
     # Build Bowtie Index
-    bowtie2-build --threads !{task.cpus} --quiet !{contigs} $INDEX
+    bowtie2-build --threads ${task.cpus} --quiet ${contigs} \$INDEX
 
     # Run Bowtie
-    bowtie2 -p !{task.cpus} !{bowtieParams} -x $INDEX \
-              --interleaved paired.fq.gz -U unpaired.fq.gz 2> !{sample}_bowtie_stats.txt \
-             | samtools view !{samtoolsViewParams} --threads !{task.cpus} -bS - \
-             | samtools sort -l 9 --threads !{task.cpus} - > !{sample}.bam
+    bowtie2 -p ${task.cpus} ${bowtieParams} -x \$INDEX \
+              --interleaved paired.fq.gz -U unpaired.fq.gz 2> ${sample}_bowtie_stats.txt \
+             | samtools view ${samtoolsViewParams} --threads ${task.cpus} -bS - \
+             | samtools sort -l 9 --threads ${task.cpus} - > ${sample}.bam
 
     # If Fragment Recruitment is selected then reads that could not be mapped should be returned
-    if [[ "!{getUnmapped}" == "TRUE" ]]; then
-        samtools bam2fq -f 4 !{sample}.bam | pigz --best --processes !{task.cpus} > !{sample}_unmapped.fq.gz
+    if [[ "${getUnmapped}" == "TRUE" ]]; then
+        samtools bam2fq -f 4 ${sample}.bam | pigz --best --processes ${task.cpus} > ${sample}_unmapped.fq.gz
     fi
-    '''
+    """
 }
 
 
@@ -251,23 +251,23 @@ process pBwa {
     tuple val("${sample}"), file("${sample}_unmapped.fq.gz"), optional: true, emit: unmappedReads
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
+    script:
     getUnmapped = getUnmapped ? "TRUE" : ""
-    '''
+    """
     # Build BWA Index
-    bwa index !{contigs}
+    bwa index ${contigs}
 
     # Run BWA
-    bwa mem !{bwaParams} -p  \
-       -t !{task.cpus} !{contigs} <(cat !{pairedReads} !{unpairedReads}) - \
-      | samtools view !{samtoolsViewParams} -@ !{task.cpus} -S -b - \
-      | samtools sort -l 9 -@ !{task.cpus} - > !{sample}.bam
+    bwa mem ${bwaParams} -p  \
+       -t ${task.cpus} ${contigs} <(cat ${pairedReads} ${unpairedReads}) - \
+      | samtools view ${samtoolsViewParams} -@ ${task.cpus} -S -b - \
+      | samtools sort -l 9 -@ ${task.cpus} - > ${sample}.bam
 
     # If Fragment Recruitment is selected then reads that could not be mapped should be returned
-    if [[ "!{getUnmapped}" == "TRUE" ]]; then
-        samtools bam2fq -f 4 !{sample}.bam | pigz --best --processes !{task.cpus} > !{sample}_unmapped.fq.gz
+    if [[ "${getUnmapped}" == "TRUE" ]]; then
+        samtools bam2fq -f 4 ${sample}.bam | pigz --best --processes ${task.cpus} > ${sample}_unmapped.fq.gz
     fi
-    '''
+    """
 }
 
 
@@ -297,23 +297,23 @@ process pBwa2 {
     tuple val("${sample}"), file("${sample}_unmapped.fq.gz"), optional: true, emit: unmappedReads
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
+    script:
     getUnmapped = getUnmapped ? "TRUE" : ""
-    '''
+    """
     # Build BWA2 Index
-    bwa-mem2 index !{contigs}
+    bwa-mem2 index ${contigs}
 
     # Run BWA
-    bwa-mem2 mem !{bwaParams} -p  \
-       -t !{task.cpus} !{contigs} <(cat !{pairedReads} !{unpairedReads}) - \
-      | samtools view !{samtoolsViewParams} -@ !{task.cpus} -S -b - \
-      | samtools sort -l 9 -@ !{task.cpus} - > !{sample}.bam
+    bwa-mem2 mem ${bwaParams} -p  \
+       -t ${task.cpus} ${contigs} <(cat ${pairedReads} ${unpairedReads}) - \
+      | samtools view ${samtoolsViewParams} -@ ${task.cpus} -S -b - \
+      | samtools sort -l 9 -@ ${task.cpus} - > ${sample}.bam
 
     # If Fragment Recruitment is selected then reads that could not be mapped should be returned
-    if [[ "!{getUnmapped}" == "TRUE" ]]; then
-        samtools bam2fq -f 4 !{sample}.bam | pigz --best --processes !{task.cpus} > !{sample}_unmapped.fq.gz
+    if [[ "${getUnmapped}" == "TRUE" ]]; then
+        samtools bam2fq -f 4 ${sample}.bam | pigz --best --processes ${task.cpus} > ${sample}_unmapped.fq.gz
     fi
-    '''
+    """
 }
 
 
@@ -347,7 +347,7 @@ process pMetabat {
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
 
-    shell:
+    script:
     DO_NOT_ESTIMATE_QUALITY = -1 
     MEDIAN_QUALITY=Double.parseDouble(medianQuality)
     percentIdentity = MEDIAN_QUALITY != DO_NOT_ESTIMATE_QUALITY ? \

--- a/modules/binning/shortReadBinning.nf
+++ b/modules/binning/shortReadBinning.nf
@@ -36,7 +36,7 @@ process pGetMappingQuality {
     tuple val("${sample}"), file("${sample}_flagstat_failed.tsv"), emit: flagstatFailed
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
+    script:
     template 'mapping_quality.sh'
 }
 
@@ -64,7 +64,7 @@ process pMetabinner {
     tuple val("${sample}"), file("${sample}_bin_contig_mapping.tsv"), optional: true, emit: binContigMapping
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
+    script:
     template 'metabinner.sh'
 }
 
@@ -87,12 +87,12 @@ process pMaxBin {
     tuple val("${sample}"), env(NEW_TYPE), file("${TYPE}_${sample}/out.*.fasta"), optional: true, emit: bins
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
-    '''
-    NEW_TYPE="!{TYPE}_maxbin"
-    mkdir !{TYPE}_!{sample}
-    run_MaxBin.pl -preserve_intermediate -contig !{contigs} -reads !{reads} -thread !{task.cpus} -out !{TYPE}_!{sample}/out
-    '''
+    script:
+    """
+    NEW_TYPE="${TYPE}_maxbin"
+    mkdir ${TYPE}_${sample}
+    run_MaxBin.pl -preserve_intermediate -contig ${contigs} -reads ${reads} -thread ${task.cpus} -out ${TYPE}_${sample}/out
+    """
 }
 
 
@@ -135,58 +135,58 @@ process pMAGScoT {
     tuple val("${sample}"), file("${sample}_notBinned.fa"), optional: true, emit: notBinned
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
-    '''
+    script:
+    """
     # Once in a blue moon Nextflow leaves the header in the file
     # Failsafe to remove header from contigMaps file if it exists
-    sed -i '/^BIN_ID\tCONTIG\tBINNER$/d' !{contigMaps}
-    Rscript /opt/MAGScoT.R !{params.steps?.binning?.magscot?.additionalParams} -i !{contigMaps} --hmm !{allHits} -o !{sample}_MagScoT
+    sed -i '/^BIN_ID\tCONTIG\tBINNER\$/d' ${contigMaps}
+    Rscript /opt/MAGScoT.R ${params.steps?.binning?.magscot?.additionalParams} -i ${contigMaps} --hmm ${allHits} -o ${sample}_MagScoT
 
     # Create a new binning file according to the naming convention
     echo "Converting MAGScoT binning according to the naming convention"
-    echo -e 'BIN_ID\tCONTIG\tBINNER' > !{sample}_bin_contig_mapping.tsv
+    echo -e 'BIN_ID\tCONTIG\tBINNER' > ${sample}_bin_contig_mapping.tsv
 
     # Use head to get the first line, awk to print the first field (the filename),
     # and sed to remove everything up to and including the last dot (.) in the filename, leaving only the file extension.
     # Export the variable to use it in the xargs commands subshell further down
-    export EXT=$(head -n 1 !{contigMaps} | awk '{print $1}' | sed 's/.*\\.//')
+    export EXT=\$(head -n 1 ${contigMaps} | awk '{print \$1}' | sed 's/.*\\.//')
 
     # Remove the header and pipe the remaining lines to xargs to run the script line by line
-    sed 1d !{sample}_MagScoT.refined.contig_to_bin.out | xargs -n 2 sh -c '
+    sed 1d ${sample}_MagScoT.refined.contig_to_bin.out | xargs -n 2 sh -c '
         # Get the first column and separate the number, remove the leading zeros
-        binID=$(echo $0 | cut -d"_" -f4 | sed 's/^0*//')
-        CONTIG=$1
+        binID=\$(echo \$0 | cut -d"_" -f4 | sed 's/^0*//')
+        CONTIG=\$1
         # Create a file with the contigs for each bin for reconstruction with seqkit
-        echo $CONTIG >> !{sample}_bin.$binID.lst
-        echo "!{sample}_bin.$binID.$EXT\t$CONTIG\tMAGScot" >> !{sample}_bin_contig_mapping.tsv
+        echo \$CONTIG >> ${sample}_bin.\$binID.lst
+        echo "${sample}_bin.\$binID.\$EXT\t\$CONTIG\tMAGScot" >> ${sample}_bin_contig_mapping.tsv
     '
     echo "Done converting"
     # Reconstructing the bins from the converted MAGScoT output list
     echo "Reconstructing bins"
-    for bin in !{sample}_bin.*.lst; do
-        seqkit grep -f $bin !{contigs} -o ${bin%.lst}.fa.tmp
+    for bin in ${sample}_bin.*.lst; do
+        seqkit grep -f \$bin ${contigs} -o \${bin%.lst}.fa.tmp
     done
     echo "Done reconstructing bins"
 
     # Rename the bins to the naming convention
-    for bin in $(find * -name "*bin*.fa.tmp"); do
-    	BIN_NAME="$(basename ${bin})"
-    	echo "Renaming bin: ${BIN_NAME}"
+    for bin in \$(find * -name "*bin*.fa.tmp"); do
+    	BIN_NAME="\$(basename \${bin})"
+    	echo "Renaming bin: \${BIN_NAME}"
 
     	# Get id of the bin (e.g get 2 of the bin SAMPLEID_bin.2.fa.tmp)
-    	ID=$(echo ${BIN_NAME} | rev | cut -d '.' -f 3 | rev)
-    	echo "Bin id: ${ID}"
+    	ID=\$(echo \${BIN_NAME} | rev | cut -d '.' -f 3 | rev)
+    	echo "Bin id: \${ID}"
 
     	# Append bin id to every header
-    	seqkit replace  -p '(.*)' -r "\\${1} MAG=${ID}" $bin > ${BIN_NAME%.tmp}
+    	seqkit replace  -p '(.*)' -r "\\\${1} MAG=\${ID}" \$bin > \${BIN_NAME%.tmp}
     	# Remove temporary file
-    	rm $bin
+    	rm \$bin
     done
 
     # Creating un-binned contigs file
-    seqkit grep -f <(cat !{sample}_bin.*.lst) -v !{contigs} -o !{sample}_notBinned.fa.tmp
-    seqkit replace -p '(.*)' -r "\\${1} MAG=NotBinned" !{sample}_notBinned.fa.tmp > !{sample}_notBinned.fa
-    '''
+    seqkit grep -f <(cat ${sample}_bin.*.lst) -v ${contigs} -o ${sample}_notBinned.fa.tmp
+    seqkit replace -p '(.*)' -r "\\\${1} MAG=NotBinned" ${sample}_notBinned.fa.tmp > ${sample}_notBinned.fa
+    """
 }
 
 /*

--- a/templates/binStats.sh
+++ b/templates/binStats.sh
@@ -1,31 +1,31 @@
 # Create temporary directory
-TEMP_DIR=$(basename $(mktemp))
-mkdir ${TEMP_DIR}
+TEMP_DIR=\$(basename \$(mktemp))
+mkdir \${TEMP_DIR}
 
-DEPTH=!{sample}.depth.tsv
-jgi_summarize_bam_contig_depths !{percentIdentity} !{bam} --outputDepth $DEPTH
+DEPTH=${sample}.depth.tsv
+jgi_summarize_bam_contig_depths ${percentIdentity} ${bam} --outputDepth \$DEPTH
 
 # Add sample and bin information to every contig in depth file
-BIN_CONTIG_MAPPING=!{binContigMapping}
-BIN_DEPTH=!{sample}_contigs_depth.tsv
-head -n 1 *.depth.tsv  | sed "s/^.*$/CONTIG\tLENGTH\tTOTAL_AVG_DEPTH\tBAM\tVARIANCE\tBIN_ID\tSAMPLE/g" > ${BIN_DEPTH}
-csvtk join -t -H -f "1;2" <(tail -n +2 *.depth.tsv) <(tail -n +2 ${BIN_CONTIG_MAPPING}) \
-	        | sed "s/$/\t!{sample}/g" >> ${BIN_DEPTH}
+BIN_CONTIG_MAPPING=${binContigMapping}
+BIN_DEPTH=${sample}_contigs_depth.tsv
+head -n 1 *.depth.tsv  | sed "s/^.*\$/CONTIG\\tLENGTH\\tTOTAL_AVG_DEPTH\\tBAM\\tVARIANCE\\tBIN_ID\\tSAMPLE/g" > \${BIN_DEPTH}
+csvtk join -t -H -f "1;2" <(tail -n +2 *.depth.tsv) <(tail -n +2 \${BIN_CONTIG_MAPPING}) \\
+	        | sed "s/\$/\\t${sample}/g" >> \${BIN_DEPTH}
 
 # Compute bin statistics
-SEQKIT_BIN_STATS=${TEMP_DIR}/seqkit_bin_stats.tsv
-seqkit stat --threads !{task.cpus} -Ta !{bins} | sed '1s/^file/BIN_ID/' | sed '1s/^/SAMPLE\t/' \
-	| sed "1 ! s/^/!{sample}\t/" > ${SEQKIT_BIN_STATS}
+SEQKIT_BIN_STATS=\${TEMP_DIR}/seqkit_bin_stats.tsv
+seqkit stat --threads ${task.cpus} -Ta ${bins} | sed '1s/^file/BIN_ID/' | sed '1s/^/SAMPLE\\t/' \\
+	| sed "1 ! s/^/${sample}\\t/" > \${SEQKIT_BIN_STATS}
 
 # Compute average depth
-BIN_AVG_DEPTH=${TEMP_DIR}/bin_avg_depth.tsv
-for id in $(cut -f 6 ${BIN_DEPTH} | tail -n +2 | sort | uniq); do
-       mean=$(awk -v bin=$id ' $6 == bin  { total += $3; count++ } END { print total/count }' ${BIN_DEPTH})
-       echo -e "$id\t$mean" 
-done | sed '1s/^/BIN_ID\tCOVERAGE\n/' > ${BIN_AVG_DEPTH}
+BIN_AVG_DEPTH=\${TEMP_DIR}/bin_avg_depth.tsv
+for id in \$(cut -f 6 \${BIN_DEPTH} | tail -n +2 | sort | uniq); do
+       mean=\$(awk -v bin=\$id ' \$6 == bin  { total += \$3; count++ } END { print total/count }' \${BIN_DEPTH})
+       echo -e "\$id\\t\$mean" 
+done | sed '1s/^/BIN_ID\\tCOVERAGE\\n/' > \${BIN_AVG_DEPTH}
 
 # Add average depth to seqkit stats
-csvtk  join -t -f "BIN_ID" ${SEQKIT_BIN_STATS} ${BIN_AVG_DEPTH} > !{sample}_bins_stats.tsv
+csvtk  join -t -f "BIN_ID" \${SEQKIT_BIN_STATS} \${BIN_AVG_DEPTH} > ${sample}_bins_stats.tsv
 
 # Fix for ownership issue https://github.com/nextflow-io/nextflow/issues/4565
-chmod a+rw -R ${TEMP_DIR}
+chmod a+rw -R \${TEMP_DIR}

--- a/templates/binStats.sh
+++ b/templates/binStats.sh
@@ -10,7 +10,7 @@ BIN_CONTIG_MAPPING=${binContigMapping}
 BIN_DEPTH=${sample}_contigs_depth.tsv
 head -n 1 *.depth.tsv  | sed "s/^.*\$/CONTIG\\tLENGTH\\tTOTAL_AVG_DEPTH\\tBAM\\tVARIANCE\\tBIN_ID\\tSAMPLE/g" > \${BIN_DEPTH}
 csvtk join -t -H -f "1;2" <(tail -n +2 *.depth.tsv) <(tail -n +2 \${BIN_CONTIG_MAPPING}) \\
-	        | sed "s/\$/\\t${sample}/g" >> \${BIN_DEPTH}
+	        | sed "s|\$|\\t${sample}|g" >> \${BIN_DEPTH}
 
 # Compute bin statistics
 SEQKIT_BIN_STATS=\${TEMP_DIR}/seqkit_bin_stats.tsv

--- a/templates/coverm.sh
+++ b/templates/coverm.sh
@@ -1,18 +1,18 @@
-readlink -f !{list_of_representatives} > list.txt 
+readlink -f ${list_of_representatives} > list.txt 
 
-additionalParams=" !{percentIdentity} !{covermParams} " 
+additionalParams=" ${percentIdentity} ${covermParams} " 
 covermCountParams=" --min-covered-fraction 0 "
 
-coverm genome -t !{task.cpus} ${additionalParams} -b !{mapping} \
-	--genome-fasta-list list.txt --methods mean --output-file !{sample}_mean.tsv && sed -i '1 s| Mean$||' !{sample}_mean.tsv
-coverm genome -t !{task.cpus} ${additionalParams} -b !{mapping} \
-	--genome-fasta-list list.txt --methods trimmed_mean --output-file !{sample}_trimmed_mean.tsv && sed -i '1 s| Trimmed Mean$||' !{sample}_trimmed_mean.tsv
-coverm genome -t !{task.cpus} -b !{mapping} ${covermCountParams} \
-	--genome-fasta-list list.txt --methods count  --output-file !{sample}_count.tsv  && sed -i '1 s| Read Count$||' !{sample}_count.tsv
-coverm genome -t !{task.cpus} ${additionalParams} -b !{mapping} \
-	--genome-fasta-list list.txt  --methods rpkm  --output-file !{sample}_rpkm.tsv  && sed -i '1 s| RPKM$||' !{sample}_rpkm.tsv
-coverm genome -t !{task.cpus} ${additionalParams} -b !{mapping} \
-	--genome-fasta-list list.txt --methods tpm --output-file !{sample}_tpm.tsv && sed -i '1 s| TPM$||' !{sample}_tpm.tsv
-coverm genome -t !{task.cpus} ${additionalParams} -b !{mapping} \
-	--genome-fasta-list list.txt --methods relative_abundance --output-file !{sample}_relative_abundance.tsv \
-	&& sed -i '1 s| Relative Abundance (%)$||' !{sample}_relative_abundance.tsv
+coverm genome -t ${task.cpus} \${additionalParams} -b ${mapping} \\
+	--genome-fasta-list list.txt --methods mean --output-file ${sample}_mean.tsv && sed -i '1 s| Mean\$||' ${sample}_mean.tsv
+coverm genome -t ${task.cpus} \${additionalParams} -b ${mapping} \\
+	--genome-fasta-list list.txt --methods trimmed_mean --output-file ${sample}_trimmed_mean.tsv && sed -i '1 s| Trimmed Mean\$||' ${sample}_trimmed_mean.tsv
+coverm genome -t ${task.cpus} -b ${mapping} \${covermCountParams} \\
+	--genome-fasta-list list.txt --methods count  --output-file ${sample}_count.tsv  && sed -i '1 s| Read Count\$||' ${sample}_count.tsv
+coverm genome -t ${task.cpus} \${additionalParams} -b ${mapping} \\
+	--genome-fasta-list list.txt  --methods rpkm  --output-file ${sample}_rpkm.tsv  && sed -i '1 s| RPKM\$||' ${sample}_rpkm.tsv
+coverm genome -t ${task.cpus} \${additionalParams} -b ${mapping} \\
+	--genome-fasta-list list.txt --methods tpm --output-file ${sample}_tpm.tsv && sed -i '1 s| TPM\$||' ${sample}_tpm.tsv
+coverm genome -t ${task.cpus} \${additionalParams} -b ${mapping} \\
+	--genome-fasta-list list.txt --methods relative_abundance --output-file ${sample}_relative_abundance.tsv \\
+	&& sed -i '1 s| Relative Abundance (%)\$||' ${sample}_relative_abundance.tsv

--- a/templates/mapping_quality.sh
+++ b/templates/mapping_quality.sh
@@ -1,10 +1,10 @@
-base=!{sample}_flagstat
-out=${base}.tsv
-echo -e "!{sample}\t!{sample}\tSAMPLE" > $out
-samtools flagstat -@ !{task.cpus} -O tsv !{bam} >> $out
+base=${sample}_flagstat
+out=\${base}.tsv
+echo -e "${sample}\\t${sample}\\tSAMPLE" > \$out
+samtools flagstat -@ ${task.cpus} -O tsv ${bam} >> \$out
 
-cut -f 3 $out | paste -s -d '\t'  > ${base}_failed.tsv
-cut -f 2 $out | paste -s -d '\t' >> ${base}_failed.tsv
-cut -f 3 $out | paste -s -d '\t' > ${base}_passed.tsv
-cut -f 1 $out | paste -s -d '\t' >> ${base}_passed.tsv
+cut -f 3 \$out | paste -s -d '\\t'  > \${base}_failed.tsv
+cut -f 2 \$out | paste -s -d '\\t' >> \${base}_failed.tsv
+cut -f 3 \$out | paste -s -d '\\t' > \${base}_passed.tsv
+cut -f 1 \$out | paste -s -d '\\t' >> \${base}_passed.tsv
 

--- a/templates/metabat.sh
+++ b/templates/metabat.sh
@@ -1,49 +1,49 @@
 shopt -s nullglob
 
 # Run metabat
-!{percentIdentity}  runMetaBat.sh !{metabatParams} !{contigs} !{bam}
+${percentIdentity}  runMetaBat.sh ${metabatParams} ${contigs} ${bam}
 
 # Create temporary directory
-TEMP_DIR=$(basename $(mktemp))
-mkdir ${TEMP_DIR}
+TEMP_DIR=\$(basename \$(mktemp))
+mkdir \${TEMP_DIR}
 
-BIN_CONTIG_MAPPING=!{sample}_bin_contig_mapping.tsv
-echo -e "BIN_ID\tCONTIG\tBINNER" > ${BIN_CONTIG_MAPPING}
-for bin in $(find $(basename !{contigs})* -name "bin*.fa"); do
-	BIN_NAME="!{sample}_$(basename ${bin})"
+BIN_CONTIG_MAPPING=${sample}_bin_contig_mapping.tsv
+echo -e "BIN_ID\\tCONTIG\\tBINNER" > \${BIN_CONTIG_MAPPING}
+for bin in \$(find \$(basename ${contigs})* -name "bin*.fa"); do
+	BIN_NAME="${sample}_\$(basename \${bin})"
 
 	# Get id of the bin (e.g get 2 of the bin SAMPLEID_bin.2.fa)
-	ID=$(echo ${BIN_NAME} | rev | cut -d '.' -f 2 | rev)
+	ID=\$(echo \${BIN_NAME} | rev | cut -d '.' -f 2 | rev)
 
 	# Append bin id to every header
-	seqkit replace  -p '(.*)' -r "\${1} MAG=${ID}" $bin > ${BIN_NAME}
+	seqkit replace  -p '(.*)' -r "\\\${1} MAG=\${ID}" \$bin > \${BIN_NAME}
 
 	# Create bin to contig mapping and add the used binner to each line
-	grep ">" ${bin} | sed 's/>//g' \
-		| sed "s/^/${BIN_NAME}\t/g;s/$/\tmetabat/" >> ${BIN_CONTIG_MAPPING}
+	grep ">" \${bin} | sed 's/>//g' \\
+		| sed "s/^/\${BIN_NAME}\\t/g;s/\$/\\tmetabat/" >> \${BIN_CONTIG_MAPPING}
 done
 
 # return not binned fasta files
 BINNED_IDS=binned.tsv
-grep -h ">" $(basename !{contigs})*/bin* | tr -d ">" > ${BINNED_IDS}
-if [ -s ${BINNED_IDS} ]; then
+grep -h ">" \$(basename ${contigs})*/bin* | tr -d ">" > \${BINNED_IDS}
+if [ -s \${BINNED_IDS} ]; then
         # Get all not binned Ids
-        NOT_BINNED=!{sample}_notBinned.fa
-	seqkit grep -vf ${BINNED_IDS} !{contigs} \
-	 | seqkit replace  -p '(.*)' -r "\${1} MAG=NotBinned" > ${NOT_BINNED}
+        NOT_BINNED=${sample}_notBinned.fa
+	seqkit grep -vf \${BINNED_IDS} ${contigs} \\
+	 | seqkit replace  -p '(.*)' -r "\\\${1} MAG=NotBinned" > \${NOT_BINNED}
 fi
 
 # return not binned fasta files
 BINNED_IDS=binned.tsv
-NOT_BINNED=!{sample}_notBinned.fa
-grep -h ">" $(basename !{contigs})*/bin* | tr -d ">" > ${BINNED_IDS}
-if [ -s ${BINNED_IDS} ]; then
+NOT_BINNED=${sample}_notBinned.fa
+grep -h ">" \$(basename ${contigs})*/bin* | tr -d ">" > \${BINNED_IDS}
+if [ -s \${BINNED_IDS} ]; then
 	# Get all not binned Ids
-	seqkit grep -vf ${BINNED_IDS} !{contigs} \
-		| seqkit replace  -p '(.*)' -r "\${1} MAG=NotBinned" > ${NOT_BINNED}
+	seqkit grep -vf \${BINNED_IDS} ${contigs} \\
+		| seqkit replace  -p '(.*)' -r "\\\${1} MAG=NotBinned" > \${NOT_BINNED}
 else
-	seqkit replace  -p '(.*)' -r "\${1} MAG=NotBinned" !{contigs} > ${NOT_BINNED}
+	seqkit replace  -p '(.*)' -r "\\\${1} MAG=NotBinned" ${contigs} > \${NOT_BINNED}
 fi
 
 # Fix for ownership issue https://github.com/nextflow-io/nextflow/issues/4565
-chmod a+rw -R ${TEMP_DIR}
+chmod a+rw -R \${TEMP_DIR}

--- a/templates/metabinner.sh
+++ b/templates/metabinner.sh
@@ -1,64 +1,64 @@
-DEPTH="$(basename !{contigs}).depth.txt"
-COVERAGE="$(pwd)/coverage_profile.tsv"
-metabinner_path=$(dirname $(which run_metabinner.sh))
-CONTIGS="$(pwd)/contigs.fasta"
-RESULT="$(pwd)/result"
+DEPTH="\$(basename ${contigs}).depth.txt"
+COVERAGE="\$(pwd)/coverage_profile.tsv"
+metabinner_path=\$(dirname \$(which run_metabinner.sh))
+CONTIGS="\$(pwd)/contigs.fasta"
+RESULT="\$(pwd)/result"
 
-MIN_LENGTH=!{params.steps.binning.metabinner.minContigLength}
-KMER_SIZE=!{params.steps.binning.metabinner.kmerSize}
+MIN_LENGTH=${params.steps.binning.metabinner.minContigLength}
+KMER_SIZE=${params.steps.binning.metabinner.kmerSize}
 
 # Create temporary directory
-TEMP_DIR=$(mktemp -d -p .)
+TEMP_DIR=\$(mktemp -d -p .)
 
 # Metabinner works only with unzipped fasta files
-gunzip -dc !{contigs} | seqkit seq --quiet -m ${MIN_LENGTH} > $CONTIGS
+gunzip -dc ${contigs} | seqkit seq --quiet -m \${MIN_LENGTH} > \$CONTIGS
 
 # Create coverage depth file based on the alignment
-/usr/local/bin/scripts/jgi_summarize_bam_contig_depths --minContigLength $MIN_LENGTH \
-	--noIntraDepthVariance --outputDepth $DEPTH !{bam}
-cut -f -1,4- $DEPTH > $COVERAGE
+/usr/local/bin/scripts/jgi_summarize_bam_contig_depths --minContigLength \$MIN_LENGTH \\
+	--noIntraDepthVariance --outputDepth \$DEPTH ${bam}
+cut -f -1,4- \$DEPTH > \$COVERAGE
 
 # Create a kmer profile 
-python /usr/local/bin/scripts/gen_kmer.py $CONTIGS $((MIN_LENGTH-1)) ${KMER_SIZE}
+python /usr/local/bin/scripts/gen_kmer.py \$CONTIGS \$((MIN_LENGTH-1)) \${KMER_SIZE}
 
 # fix shebang in all perl files
-sed -i '1 s/^.*$/#!\/usr\/bin\/env perl/' /usr/local/bin/auxiliary/*.pl
+sed -i '1 s/^.*\$/#!\\/usr\\/bin\\/env perl/' /usr/local/bin/auxiliary/*.pl
 
 # run metabinner
-bash /usr/local/bin/run_metabinner.sh -a $CONTIGS -o $RESULT -d $COVERAGE -k $(pwd)/*.csv -p /usr/local/bin -t !{task.cpus}
+bash /usr/local/bin/run_metabinner.sh -a \$CONTIGS -o \$RESULT -d \$COVERAGE -k \$(pwd)/*.csv -p /usr/local/bin -t ${task.cpus}
 
 # Create bins
-METABINNER_RESULT=${RESULT}/metabinner_res/metabinner_result.tsv 
-OLD_BINS=${TEMP_DIR}/old_bins
-BIN_CONTIG_MAPPING=!{sample}_bin_contig_mapping.tsv
-echo -e "BIN_ID\tCONTIG\tBINNER" > ${BIN_CONTIG_MAPPING}
-mkdir ${OLD_BINS}
-for binId in $(cut -f 2 $METABINNER_RESULT | sort | uniq); do
+METABINNER_RESULT=\${RESULT}/metabinner_res/metabinner_result.tsv 
+OLD_BINS=\${TEMP_DIR}/old_bins
+BIN_CONTIG_MAPPING=${sample}_bin_contig_mapping.tsv
+echo -e "BIN_ID\\tCONTIG\\tBINNER" > \${BIN_CONTIG_MAPPING}
+mkdir \${OLD_BINS}
+for binId in \$(cut -f 2 \$METABINNER_RESULT | sort | uniq); do
 
 	# Create bins with the old header and the new header
-	BIN_NAME="!{sample}_bin.${binId}.fa"
-	OLD_BIN_NAME=${OLD_BINS}/"!{sample}_bin.${binId}.fa"
-	grep -e "$(printf '\t')${binId}$" $METABINNER_RESULT | cut -f 1 >> ${binId}.tsv 
-	seqkit grep --threads !{task.cpus} -f ${binId}.tsv $CONTIGS \
-		| seqkit replace -p "\s.+" > ${OLD_BIN_NAME}
-	seqkit replace  -p '(.*)' -r "\${1} MAG=${binId}" ${OLD_BIN_NAME} > ${BIN_NAME}
+	BIN_NAME="${sample}_bin.\${binId}.fa"
+	OLD_BIN_NAME=\${OLD_BINS}/"${sample}_bin.\${binId}.fa"
+	grep -e "\$(printf '\\t')\${binId}\$" \$METABINNER_RESULT | cut -f 1 >> \${binId}.tsv 
+	seqkit grep --threads ${task.cpus} -f \${binId}.tsv \$CONTIGS \\
+		| seqkit replace -p "\\s.+" > \${OLD_BIN_NAME}
+	seqkit replace  -p '(.*)' -r "\\\${1} MAG=\${binId}" \${OLD_BIN_NAME} > \${BIN_NAME}
 
 	# Create bin to contig mapping and add the used binning tool to each line
-	grep ">" ${OLD_BIN_NAME} | sed 's/>//g' \
-		| sed "s/^/${BIN_NAME}\t/g;s/$/\tmetabinner/" >> ${BIN_CONTIG_MAPPING}
+	grep ">" \${OLD_BIN_NAME} | sed 's/>//g' \\
+		| sed "s/^/\${BIN_NAME}\\t/g;s/\$/\\tmetabinner/" >> \${BIN_CONTIG_MAPPING}
 done
 
 
 # return not binned fasta files
 BINNED_IDS=binned.tsv
-NOT_BINNED=!{sample}_notBinned.fa
-grep -h ">" *.fa | tr -d ">" > ${BINNED_IDS}
-if [ -s ${BINNED_IDS} ]; then
+NOT_BINNED=${sample}_notBinned.fa
+grep -h ">" *.fa | tr -d ">" > \${BINNED_IDS}
+if [ -s \${BINNED_IDS} ]; then
        # Get all not binned Ids
-        seqkit grep -vf ${BINNED_IDS} !{contigs} \
-         | seqkit replace  -p '(.*)' -r "\${1} MAG=NotBinned" > ${NOT_BINNED}
+        seqkit grep -vf \${BINNED_IDS} ${contigs} \\
+         | seqkit replace  -p '(.*)' -r "\\\${1} MAG=NotBinned" > \${NOT_BINNED}
 else
-        seqkit replace  -p '(.*)' -r "\${1} MAG=NotBinned" !{contigs} > ${NOT_BINNED}
+        seqkit replace  -p '(.*)' -r "\\\${1} MAG=NotBinned" ${contigs} > \${NOT_BINNED}
 fi
 
 

--- a/templates/metacoag.sh
+++ b/templates/metacoag.sh
@@ -5,48 +5,48 @@ source /opt/conda/bin/activate
 conda activate metacoag
 
 # compute contig abundance 
-coverm contig -t !{task.cpus} --bam-files !{bam} | tail -n +2 > assembly_depth.tsv
+coverm contig -t ${task.cpus} --bam-files ${bam} | tail -n +2 > assembly_depth.tsv
 
 # Update contig names to make it consistent with the gfa and flyes assembly info file
-csvtk replace -r {kv}  -f 1 -H -t -k <(awk -F $'\t' ' { t = $1; $1 = $2; $2 = t; print; }' OFS=$'\t' !{headerMapping} ) assembly_depth.tsv -p "(.*)"  > assembly_depth_final.tsv
-seqkit replace -p '(.*)' -r '{kv}' \
-	-k <(awk -F $'\t' ' { t = $1; $1 = $2; $2 = t; print; } ' OFS=$'\t' !{headerMapping})  !{contigs} > contigs.fa.gz
+csvtk replace -r {kv}  -f 1 -H -t -k <(awk -F \$'\\t' ' { t = \$1; \$1 = \$2; \$2 = t; print; }' OFS=\$'\\t' ${headerMapping} ) assembly_depth.tsv -p "(.*)"  > assembly_depth_final.tsv
+seqkit replace -p '(.*)' -r '{kv}' \\
+	-k <(awk -F \$'\\t' ' { t = \$1; \$1 = \$2; \$2 = t; print; } ' OFS=\$'\\t' ${headerMapping})  ${contigs} > contigs.fa.gz
 
 # Run MetaCoAG
-metacoag --assembler flye --graph !{graph}  --nthreads !{task.cpus} --contigs contigs.fa.gz \
-	--paths !{flyeAssemblyInfo} !{params.steps.binningONT.metacoag.additionalParams} --abundance assembly_depth_final.tsv --output .
+metacoag --assembler flye --graph ${graph}  --nthreads ${task.cpus} --contigs contigs.fa.gz \\
+	--paths ${flyeAssemblyInfo} ${params.steps.binningONT.metacoag.additionalParams} --abundance assembly_depth_final.tsv --output .
 
 # Rename contig and file names according to toolkit specification
-BIN_CONTIG_MAPPING=!{sample}_bin_contig_mapping.tsv
+BIN_CONTIG_MAPPING=${sample}_bin_contig_mapping.tsv
 BINNED_IDS=binned.tsv
-echo -e "BIN_ID\tCONTIG" > ${BIN_CONTIG_MAPPING}
-for bin in  $(find bins -name "bin*.fasta") ; do
+echo -e "BIN_ID\\tCONTIG" > \${BIN_CONTIG_MAPPING}
+for bin in  \$(find bins -name "bin*.fasta") ; do
 
 	# Get id of the bin (e.g get 2 of the bin SAMPLEID_bin.2.fa)
-	ID=$(echo ${bin} | cut -f 2 -d '_' | cut -f 1 -d '.')
+	ID=\$(echo \${bin} | cut -f 2 -d '_' | cut -f 1 -d '.')
 
-	BIN_NAME="!{sample}_bin.${ID}.fa"
+	BIN_NAME="${sample}_bin.\${ID}.fa"
 
         # Add BIN ID
-	seqkit replace -p '(.*)'  -r '{kv}' -k !{headerMapping} ${bin} \
-	| tee >( grep -h ">" | tr -d '>' >> ${BINNED_IDS} ) \
- 	| seqkit replace  -p '(.*)' -r "\${1} MAG=${ID}" > ${BIN_NAME}
+	seqkit replace -p '(.*)'  -r '{kv}' -k ${headerMapping} \${bin} \\
+	| tee >( grep -h ">" | tr -d '>' >> \${BINNED_IDS} ) \\
+ 	| seqkit replace  -p '(.*)' -r "\\\${1} MAG=\${ID}" > \${BIN_NAME}
 
 	# Create bin to contig mapping
-	grep ">" ${bin} | sed 's/>//g' \
-        | csvtk replace -r {kv}  -f 1 -H -t -k !{headerMapping} -p "(.*)" \
-     	| sed "s/^/${BIN_NAME}\t/g" >> ${BIN_CONTIG_MAPPING}
+	grep ">" \${bin} | sed 's/>//g' \\
+        | csvtk replace -r {kv}  -f 1 -H -t -k ${headerMapping} -p "(.*)" \\
+     	| sed "s/^/\${BIN_NAME}\\t/g" >> \${BIN_CONTIG_MAPPING}
 done
 
 # return not binned fasta files
 BINNED_IDS=binned.tsv
-NOT_BINNED=!{sample}_notBinned.fa
-grep -h ">" $(basename !{contigs})*/bin* | tr -d ">" > ${BINNED_IDS}
-if [ -s ${BINNED_IDS} ]; then
+NOT_BINNED=${sample}_notBinned.fa
+grep -h ">" \$(basename ${contigs})*/bin* | tr -d ">" > \${BINNED_IDS}
+if [ -s \${BINNED_IDS} ]; then
 	# Get all not binned Ids
-	seqkit grep -vf ${BINNED_IDS} !{contigs} \
-	| seqkit replace  -p '(.*)' -r "\${1} MAG=NotBinned" > ${NOT_BINNED}
+	seqkit grep -vf \${BINNED_IDS} ${contigs} \\
+	| seqkit replace  -p '(.*)' -r "\\\${1} MAG=NotBinned" > \${NOT_BINNED}
 else
-	seqkit replace  -p '(.*)' -r "\${1} MAG=NotBinned" !{contigs} > ${NOT_BINNED}
+	seqkit replace  -p '(.*)' -r "\\\${1} MAG=NotBinned" ${contigs} > \${NOT_BINNED}
 fi
 


### PR DESCRIPTION
Replaced shell with script for plasmids module referring #394

- Refactored `shell` section to `script` section
- Refactored `'''` to `"""` where needed due to nextflow and bash variable substitution restrictions
- Escaped `\` to `\\` in templates, this is not needed for triple quote sections
- Escaped `$` to `\$` in templates and triple quote sections, as these will be bash variable substitutions
- Refactored `sed` delimiter from `/` to `|` where it is preceded with a `$` as groovy has `$/` reserved for slashy-strings
- Refactored `!{variable}` to `${variable}`, as these are nextflow variable substitutions