### PR TITLE
chore(fragmentRecruitment): replace shell with script

### DIFF
--- a/modules/fragmentRecruitment/frhit.nf
+++ b/modules/fragmentRecruitment/frhit.nf
@@ -39,27 +39,27 @@ process pFrHit {
     tuple val("${sample}"), file("coverage"), optional: true, emit: coverageStats
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
-    '''
+    script:
+    """
     mkdir coverage
-    seqkit fq2fa !{reads} -o reads.fasta.gz
-    AVG_LEN=$(seqkit stats -T reads.fasta.gz | tail -n 1 | cut -f 7)
-    HALF_AVG_LEN=$(bc <<< "${AVG_LEN} / 2")
+    seqkit fq2fa ${reads} -o reads.fasta.gz
+    AVG_LEN=\$(seqkit stats -T reads.fasta.gz | tail -n 1 | cut -f 7)
+    HALF_AVG_LEN=\$(bc <<< "\${AVG_LEN} / 2")
     gunzip reads.fasta.gz
-    echo "Min. Coverage Parameter: ${HALF_AVG_LEN}"
-    fr-hit !{params.steps.fragmentRecruitment.frhit.additionalParams.frhit} -f 1 -m ${HALF_AVG_LEN} -T !{task.cpus} -a reads.fasta -d !{genomesCombined} -o coverage/out.psl
+    echo "Min. Coverage Parameter: \${HALF_AVG_LEN}"
+    fr-hit ${params.steps.fragmentRecruitment.frhit.additionalParams.frhit} -f 1 -m \${HALF_AVG_LEN} -T ${task.cpus} -a reads.fasta -d ${genomesCombined} -o coverage/out.psl
     if [ -s "coverage/out.psl" ] 
     then
-      psl2sam.pl coverage/out.psl | samtools view -bT !{genomesCombined} - | samtools calmd -E - genomes | samtools view -Sb - | samtools sort -o - out > !{sample}.bam 2> /dev/null
-      coverm genome -t !{task.cpus} !{params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b !{sample}.bam --genome-fasta-list !{genomesList} --methods count --output-file coverage/readCount.tsv
-      coverm genome -t !{task.cpus} !{params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b !{sample}.bam --genome-fasta-list !{genomesList} --methods covered_fraction --output-file coverage/coveredFraction.tsv
-      coverm genome -t !{task.cpus} !{params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b !{sample}.bam --genome-fasta-list !{genomesList} --methods covered_bases --output-file coverage/coveredBases.tsv
-      coverm genome -t !{task.cpus} !{params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b !{sample}.bam --genome-fasta-list !{genomesList} --methods length --output-file coverage/genomeLength.tsv
-      coverm genome -t !{task.cpus} !{params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b !{sample}.bam --genome-fasta-list !{genomesList} --methods trimmed_mean --output-file coverage/trimmedMean.tsv
+      psl2sam.pl coverage/out.psl | samtools view -bT ${genomesCombined} - | samtools calmd -E - genomes | samtools view -Sb - | samtools sort -o - out > ${sample}.bam 2> /dev/null
+      coverm genome -t ${task.cpus} ${params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b ${sample}.bam --genome-fasta-list ${genomesList} --methods count --output-file coverage/readCount.tsv
+      coverm genome -t ${task.cpus} ${params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b ${sample}.bam --genome-fasta-list ${genomesList} --methods covered_fraction --output-file coverage/coveredFraction.tsv
+      coverm genome -t ${task.cpus} ${params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b ${sample}.bam --genome-fasta-list ${genomesList} --methods covered_bases --output-file coverage/coveredBases.tsv
+      coverm genome -t ${task.cpus} ${params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b ${sample}.bam --genome-fasta-list ${genomesList} --methods length --output-file coverage/genomeLength.tsv
+      coverm genome -t ${task.cpus} ${params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b ${sample}.bam --genome-fasta-list ${genomesList} --methods trimmed_mean --output-file coverage/trimmedMean.tsv
     else
       echo "No reads could be recruited!"
     fi
-    '''
+    """
 }
 
 
@@ -100,16 +100,16 @@ process pCombinedAlignmentAnalysis {
     path("coverage"), emit: coverageStats
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
-    '''
+    script:
+    """
     mkdir coverage
-    samtools merge -@ !{task.cpus} combined_alignments.bam !{alignments}
-    coverm genome -t !{task.cpus} !{params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b combined_alignments.bam --genome-fasta-list !{genomesList} --methods count --output-file coverage/readCount.tsv
-    coverm genome -t !{task.cpus} !{params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b combined_alignments.bam --genome-fasta-list !{genomesList} --methods covered_fraction --output-file coverage/coveredFraction.tsv
-    coverm genome -t !{task.cpus} !{params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b combined_alignments.bam --genome-fasta-list !{genomesList} --methods covered_bases --output-file coverage/coveredBases.tsv
-    coverm genome -t !{task.cpus} !{params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b combined_alignments.bam --genome-fasta-list !{genomesList} --methods length --output-file coverage/genomeLength.tsv
-    coverm genome -t !{task.cpus} !{params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b combined_alignments.bam --genome-fasta-list !{genomesList} --methods trimmed_mean --output-file coverage/trimmedMean.tsv
-    '''
+    samtools merge -@ ${task.cpus} combined_alignments.bam ${alignments}
+    coverm genome -t ${task.cpus} ${params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b combined_alignments.bam --genome-fasta-list ${genomesList} --methods count --output-file coverage/readCount.tsv
+    coverm genome -t ${task.cpus} ${params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b combined_alignments.bam --genome-fasta-list ${genomesList} --methods covered_fraction --output-file coverage/coveredFraction.tsv
+    coverm genome -t ${task.cpus} ${params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b combined_alignments.bam --genome-fasta-list ${genomesList} --methods covered_bases --output-file coverage/coveredBases.tsv
+    coverm genome -t ${task.cpus} ${params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b combined_alignments.bam --genome-fasta-list ${genomesList} --methods length --output-file coverage/genomeLength.tsv
+    coverm genome -t ${task.cpus} ${params.steps.fragmentRecruitment.frhit.additionalParams.coverm} -b combined_alignments.bam --genome-fasta-list ${genomesList} --methods trimmed_mean --output-file coverage/trimmedMean.tsv
+    """
 
 }
 

--- a/modules/fragmentRecruitment/mashScreen.nf
+++ b/modules/fragmentRecruitment/mashScreen.nf
@@ -44,7 +44,7 @@ process pMashScreen {
     tuple val("${sample}"), file("selected_genomes.tsv"), optional: true, emit: mashScreenFilteredOutput
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
+    script:
     template "mashScreen.sh"
 }
 
@@ -66,12 +66,12 @@ process pGenomeContigMapping {
     tuple val("${sample}"), path("${sample}_genome_contig_mapping.tsv"), emit: mapping
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
-    shell:
-    '''
-    for g in $(ls -1 !{genomes}); do
-       seqkit fx2tab -i -n ${g} | sed "s/^/${g}\t/g" >> !{sample}_genome_contig_mapping.tsv
+    script:
+    """
+    for g in \$(ls -1 ${genomes}); do
+       seqkit fx2tab -i -n \${g} | sed "s/^/\${g}\t/g" >> ${sample}_genome_contig_mapping.tsv
     done
-    '''
+    """
 }
 
 
@@ -96,12 +96,12 @@ process pSaveMatchedGenomes {
     tuple val("${sample}"), val("${output}"), val(params.LOG_LEVELS.ALL), file(".command.sh"), \
       file(".command.out"), file(".command.err"), file(".command.log"), emit: logs
 
-    shell:
+    script:
     output = getOutput("${sample}", params.runid, "matches", "")
-    '''
+    """
     mkdir matches
-    cp !{genomes} matches
-    '''
+    cp ${genomes} matches
+    """
 }
 
 
@@ -424,7 +424,7 @@ process pUnzipGroup {
   output:
   path("*", type: "file")
 
-  shell:
+  script:
   '''
   for f in input/*; do  
 	cp $f . ; 
@@ -456,12 +456,12 @@ process pMashSketchGenomeGroup {
     output:
     path("*.msh"), emit: sketches
 
-    shell:
-    '''
+    script:
+    """
     for f in * ; do  
-    	mash sketch !{mashSketchParams} $f -o $(basename $f).msh
+    	mash sketch ${mashSketchParams} \$f -o \$(basename \$f).msh
     done
-    '''
+    """
 }
 
 

--- a/modules/fragmentRecruitment/processes.nf
+++ b/modules/fragmentRecruitment/processes.nf
@@ -24,50 +24,50 @@ process pCovermCount {
       tuple val("${sample}"), path("foundGenomes.tsv"), optional: true, emit: foundGenomes
       tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
-    shell:
+    script:
     DO_NOT_ESTIMATE_QUALITY = -1 
     MEDIAN_QUALITY=Double.parseDouble(medianQuality)
     percentIdentity = MEDIAN_QUALITY != DO_NOT_ESTIMATE_QUALITY ? \
 	" --min-read-percent-identity "+Utils.getMappingIdentityParam(MEDIAN_QUALITY) : " "
-    '''
-    OUT=!{sample}_stats_out
-    mkdir $OUT
-    readlink -f !{listOfRepresentatives} > list.txt 
+    """
+    OUT=${sample}_stats_out
+    mkdir \$OUT
+    readlink -f ${listOfRepresentatives} > list.txt 
    
     # Create a mapping between file path basename of the file without ending. (/path/test.1.tsv --> test.1) 
     paste -d '\t' list.txt  <(cat list.txt  | rev | cut -d '/' -f 1  | cut -d '.' -f 2- | rev) > mapping.tsv
     
     # Get covered bases
-    coverm genome -t !{task.cpus} !{covermParams} -b !{mapping} \
-        !{percentIdentity}  \
+    coverm genome -t ${task.cpus} ${covermParams} -b ${mapping} \
+        ${percentIdentity}  \
         --genome-fasta-list list.txt --methods covered_bases --output-file covTmpContent.tsv \
 
     # Get length
-    coverm genome -t !{task.cpus} -b !{mapping} --min-covered-fraction 0  \
+    coverm genome -t ${task.cpus} -b ${mapping} --min-covered-fraction 0  \
         --genome-fasta-list list.txt --methods length --output-file lengthTmpContent.tsv \
 
     # Join length and covered bases
-    join -t$'\t' -1 1 -2 1 covTmpContent.tsv lengthTmpContent.tsv > covLengthTmpContent.tsv
+    join -t\$'\t' -1 1 -2 1 covTmpContent.tsv lengthTmpContent.tsv > covLengthTmpContent.tsv
 
     # Exchange header ad add covered fraction column
-    sed -i  -e '1 s/^.*$/SAMPLE\tGENOME\tCOVERED_BASES\tLENGTH/' -e "2,$ s/^/!{sample}\t/g" covLengthTmpContent.tsv  \
+    sed -i  -e '1 s/^.*\$/SAMPLE\tGENOME\tCOVERED_BASES\tLENGTH/' -e "2,\$ s/^/${sample}\t/g" covLengthTmpContent.tsv  \
                 && echo "COVERED_FRACTION" > covLengthTmp.tsv \
-		&& awk '(NR>1){ tmp=($3/($4/100)) ; printf"%0.2f\\n", tmp }' covLengthTmpContent.tsv >> covLengthTmp.tsv \
-                && paste -d$'\t' covLengthTmpContent.tsv covLengthTmp.tsv > $OUT/coveredBases.tsv || true
+		&& awk '(NR>1){ tmp=(\$3/(\$4/100)) ; printf"%0.2f\\n", tmp }' covLengthTmpContent.tsv >> covLengthTmp.tsv \
+                && paste -d\$'\t' covLengthTmpContent.tsv covLengthTmp.tsv > \$OUT/coveredBases.tsv || true
 
     # Run other metrics like RPKM, TPM, ...
-    coverm genome  -t !{task.cpus}  -b !{mapping} \
-         !{covermParams} !{percentIdentity} \
+    coverm genome  -t ${task.cpus}  -b ${mapping} \
+         ${covermParams} ${percentIdentity} \
 	--genome-fasta-list list.txt --methods mean trimmed_mean variance length count reads_per_base rpkm tpm \
-	| sed -e '1 s/^.*$/SAMPLE\tGENOME\tMEAN\tTRIMMED_MEAN\tVARIANCE\tLENGTH\tREAD_COUNT\tREADS_PER_BASE\tRPKM\tTPM/' \
-	| sed -e "2,$ s/^/!{sample}\t/g" > $OUT/metrics.tsv || true
+	| sed -e '1 s/^.*\$/SAMPLE\tGENOME\tMEAN\tTRIMMED_MEAN\tVARIANCE\tLENGTH\tREAD_COUNT\tREADS_PER_BASE\tRPKM\tTPM/' \
+	| sed -e "2,\$ s/^/${sample}\t/g" > \$OUT/metrics.tsv || true
 
-    coveredBasesCutoff=!{params.steps?.fragmentRecruitment?.mashScreen?.coveredBasesCutoff}
+    coveredBasesCutoff=${params.steps?.fragmentRecruitment?.mashScreen?.coveredBasesCutoff}
     FOUND_GENOMES=foundGenomes.tsv
-    for b in $(awk -v coveredBases=${coveredBasesCutoff} '(NR>1){if ($5 > coveredBases) print $2}' $OUT/coveredBases.tsv); do 
-        file=$(grep -P "\t$b$" mapping.tsv | cut -f 1);
-	echo $(basename $file)  >> ${FOUND_GENOMES} 
+    for b in \$(awk -v coveredBases=\${coveredBasesCutoff} '(NR>1){if (\$5 > coveredBases) print \$2}' \$OUT/coveredBases.tsv); do 
+        file=\$(grep -P "\t\$b\$" mapping.tsv | cut -f 1);
+	echo \$(basename \$file)  >> \${FOUND_GENOMES} 
     done
-    '''
+    """
 
 }

--- a/templates/mashScreen.sh
+++ b/templates/mashScreen.sh
@@ -1,13 +1,13 @@
 set -o pipefail
 
-mash screen -p !{task.cpus} !{params?.steps?.fragmentRecruitment?.mashScreen?.additionalParams.mashScreen} !{sketch} !{pairedReads} !{singleReads} \
-	| sed "s/^/!{sample}\t/g" >> mash_screen_temp.tsv
+mash screen -p ${task.cpus} ${params?.steps?.fragmentRecruitment?.mashScreen?.additionalParams.mashScreen} ${sketch} ${pairedReads} ${singleReads} \\
+	| sed "s/^/${sample}\\t/g" >> mash_screen_temp.tsv
 
 set +o pipefail
 
-awk -v dist=!{params?.steps?.fragmentRecruitment?.mashScreen?.mashDistCutoff} \
-    -v hash=!{params?.steps?.fragmentRecruitment?.mashScreen?.mashHashCutoff} \
-    '{ if ($2 >= dist && $3 >= hash) print $7 }' <(cat mash_screen_temp.tsv | sed "s/\//\t/g") > selected_genomes_temp.tsv
+awk -v dist=${params?.steps?.fragmentRecruitment?.mashScreen?.mashDistCutoff} \\
+    -v hash=${params?.steps?.fragmentRecruitment?.mashScreen?.mashHashCutoff} \\
+    '{ if (\$2 >= dist && \$3 >= hash) print \$7 }' <(cat mash_screen_temp.tsv | sed "s/\\//\\t/g") > selected_genomes_temp.tsv
 
 
 if [ -s selected_genomes_temp.tsv ]


### PR DESCRIPTION
Replaced shell with script for plasmids module referring #394

- Refactored `shell` section to `script` section
- Refactored `'''` to `"""` where needed due to nextflow and bash variable substitution restrictions
- Escaped `\` to `\\` in templates, this is not needed for triple quote sections
- Escaped `$` to `\$` in templates and triple quote sections, as these will be bash variable substitutions
- Refactored `!{variable}` to `${variable}`, as these are nextflow variable substitutions