### PR TITLE
Feature/interleaved format

### DIFF
--- a/.github/workflows/workflow_modules.yml
+++ b/.github/workflows/workflow_modules.yml
@@ -24,7 +24,10 @@ jobs:
         run: |
           bash ./scripts/test_fullPipeline.sh   " -c  test_data/assets/aws.config    " \
                ./example_params/fullPipelineSRAQC.yml "${WORK_DIR}" ${PROFILE}  || exit 1
-
+      - name: Test if interleaved fastq input works
+        run: |
+          bash ./scripts/test_fullPipeline.sh   " -c  test_data/assets/aws.config    "   \
+               ./example_params/fullPipelineQC.yml "${WORK_DIR}" ${PROFILE} || exit 1
       - name: Test if SRA S3 Input module works with ONT data
         run: |
           bash ./scripts/test_fullPipeline.sh   " -c  test_data/assets/aws.config    " \
@@ -261,6 +264,12 @@ jobs:
                                       --input.SRA.S3.id 'ERR12263778 SRR29912082' --input.SRA.S3.sheet ./test_data/input/sraS3Input.tsv  \
                                       --input.SRA.S3.binGroup 'A A' " ./test_data/input/sraS3Expected.tsv "${WORK_DIR}" ${PROFILE}  || exit 1
 
+      - name: Test if combination of CLI based input for interleaved format works as expected
+        run: |
+          bash scripts/test_input.sh " -c  test_data/assets/aws.config \
+                                      --input.paired.r 'https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta_test/small/read1_1bla.fq.gz' \
+                                      --input.paired.names 'test1' \
+                                      " ./test_data/input/interleavedExpected.tsv "${WORK_DIR}" ${PROFILE} || exit 1
 
   mag_attributes_1:
     timeout-minutes: 2500

--- a/docs/pipeline_input.md
+++ b/docs/pipeline_input.md
@@ -23,6 +23,15 @@ Example:
 
 ```
 
+If the input reads are in interleaved format it is also possible to specify just a single column, i.e. `READS`.
+
+
+Example:
+```
+---8<--- "test_data/fullPipeline/reads_split_interleaved.tsv"
+
+```
+
 #### Command line
 
 For a small number of samples it is sometimes easier to provide them directly on the command line instead of creating a sample sheet. 
@@ -42,7 +51,10 @@ where
   * `--input.paired.names` are the sample names. If multiple samples are provided they must be enclosed in double ticks (e.g. "test1 test2").
     The number of sample names must match the number of files provided for `--input.paired.r1` and `--input.paired.r2`.
 
-The `--input.paired.r1` and `--input.paired.r2` can point to the same type of resources (URL, S3, etc.) as the `READS1` and `READS2` columns (see "Sample Sheet" section).
+  * The `--input.paired.r` parameter can be used to specify input reads in interleaved format instaed of using the `--input.paired.r1` and `--input.paired.r2` options.
+
+The `--input.paired.r1`, `--input.paired.r2` and `--input.paired.r` parameters can point to the same type of resources (URL, S3, etc.) as 
+the `READS1` and `READS2` for split columns and `READS` for interleaved format (see "Sample Sheet" section).
 See [Quickstart](quickstart.md#run-the-toolkit) section for a working example.
 
 ### Nanopore

--- a/example_params/fullPipelineQCDownload.yml
+++ b/example_params/fullPipelineQCDownload.yml
@@ -7,11 +7,13 @@ scratch: "/vol/scratch"
 publishDirMode: "symlink"
 input:
   paired:
-    sheet: "test_data/fullPipeline/reads_split_interleaved.tsv"
+    sheet: "test_data/fullPipeline/reads_split_s3_interleaved.tsv"
     watch: false
 steps:
   qc:
     fastp:
+      download:
+        s5cmdParams: " --retry-count 30 --no-verify-ssl --no-sign-request --endpoint-url https://openstack.cebitec.uni-bielefeld.de:8080 "
       additionalParams:
         fastp: "  "
         reportOnly: false

--- a/main.nf
+++ b/main.nf
@@ -113,13 +113,14 @@ workflow wOutputTable {
         ILLUMINA: it.TYPE == "ILLUMINA"
    } | set { input }
      
-   input.ILLUMINA | map { sample ->  [ sample.SAMPLE, sample.TYPE, sample.MULTI_BINNING_GROUP, sample.READS1, sample.READS2 ] } \
+   input.ILLUMINA | map { sample ->  [ sample.SAMPLE, sample.TYPE, sample.MULTI_BINNING_GROUP, sample.READS1, file(sample.READS2).name == "empty" ? "": sample.READS2 ] } \
 	 | collectFile(newLine: true, seed: "SAMPLE\tINSTRUMENT\tMULTI_BINNING_GROUP\tREADS1\tREADS2"){ it -> [ "samplesILLUMINA.tsv", it[SAMPLE_IDX] \
         + "\t" + it[INSTRUMENT_IDX] \
         + "\t" + it[MULTI_BINNING_GROUP_IDX] \
 	+ "\t" + it[FASTQ_FILE_LEFT_IDX].toString() \
 	+ "\t" + it[FASTQ_FILE_RIGHT_IDX].toString()] } \
 	| set {illuminaFile} 
+
    illuminaFile | view({ it -> it.text })
    pPublishIllumina(params.logDir, illuminaFile)
 

--- a/modules/input/module.nf
+++ b/modules/input/module.nf
@@ -256,7 +256,6 @@ workflow _wSplitReadsFiles {
 	            | map { sample -> [SAMPLE:sample[SAMPLE_IDX],READS1:file(sample[READS1_IDX]),READS2:file(sample[READS2_IDX])] }
                 | set { fastqs }
          }
-         fastqs | view
       emit:
          fastqs
 }

--- a/modules/input/module.nf
+++ b/modules/input/module.nf
@@ -178,7 +178,18 @@ workflow _wSplitReadsSheet {
          } else {
             idsFromPath | set {files}
          } 
-         files |  splitCsv(sep: '\t', header: true) | unique | set { fastqs } 
+         files |  splitCsv(sep: '\t', header: true) | branch { samples ->
+            interleaved:  samples.containsKey("READS")
+            split:  !samples.containsKey("READS")
+         } 
+         | set { fastqFormat } 
+
+         empty = file(params.tempdir + "/empty") 
+
+         // For interleaved format the 2nd fastq file is set to an empty file.
+         fastqFormat.interleaved 
+            | map { sample -> [SAMPLE:sample.SAMPLE, READS1:sample.READS, READS2:empty.toString()] }
+            | mix(fastqFormat.split) | unique | set { fastqs } 
        emit:
          fastqs
 }
@@ -191,12 +202,30 @@ workflow _wSplitReadsSheet {
 */
 workflow _wSplitReadsFiles {
        main:
-         def r1 = params.input.paired.r1.tokenize(' ')
-         def r2 = params.input.paired.r2.tokenize(' ')
-         def names = params.input.paired.names.tokenize(" ")
+        def r = null
+        def r1 = null
+        def r2 = null
+        if("r" in params.input.paired){
+            r = params.input.paired.r.tokenize(' ')
+        } else {
+            r1 = params.input.paired.r1.tokenize(' ')
+            r2 = params.input.paired.r2.tokenize(' ')
+        }
+        def names = params.input.paired.names.tokenize(" ")
 
-         if (r1.size() != r2.size() && r2.size() == r3.size() ) {
-            error "Mismatch detected: --input.paired.r1, --input.paired.r2 and --input.paired.names should have the same number of values."
+         if(r == null){
+            if (r1.size() != r2.size() || r2.size() != names.size() ) {
+                error "Mismatch detected: --input.paired.r1, --input.paired.r2 and --input.paired.names should have the same number of values."
+            }
+         } else {
+            if (r.size() != names.size() ) {
+                error "Mismatch detected: --input.paired.r and --input.paired.names should have the same number of values."
+            }
+            r1 = r
+
+            // For interleaved format the 2nd fastq file is set to an empty file.
+            empty = file(params.tempdir + "/empty") 
+            r2 = [empty.toString()] * r.size()
          }
 
          SAMPLE_IDX=0
@@ -208,8 +237,14 @@ workflow _wSplitReadsFiles {
          fastqs = channel.empty()
          if(params.input.paired.containsKey("binGroup")){
             def binGroup = params.input.paired.binGroup.tokenize(" ")
-            if (r1.size() != binGroup.size()) {
-                error "Mismatch detected: --input.paired.r and --input.paired.binGroup should have the same number of values."
+            if (r == null){
+                if (r1.size() != binGroup.size()) {
+                    error "Mismatch detected: --input.paired.r1, --input.paired.r2 and --input.paired.binGroup should have the same number of values."
+                }
+            } else {
+                if (r.size() != binGroup.size()) {
+                    error "Mismatch detected: --input.paired.r and --input.paired.binGroup should have the same number of values."
+                }
             }
 	        samples = [names, r1, r2, binGroup].transpose()
             channel.from(samples) 
@@ -221,6 +256,7 @@ workflow _wSplitReadsFiles {
 	            | map { sample -> [SAMPLE:sample[SAMPLE_IDX],READS1:file(sample[READS1_IDX]),READS2:file(sample[READS2_IDX])] }
                 | set { fastqs }
          }
+         fastqs | view
       emit:
          fastqs
 }
@@ -725,9 +761,9 @@ workflow wInputFile {
             fastqs | mix(pairedChannel) | set { fastqs }
         }
 
-        if("r1" in params.input.paired || "r2" in params.input.paired) {
+        if("r1" in params.input.paired || "r2" in params.input.paired || "r" in params.input.paired) {
             // Make sure that always left and right read is provided and the sample names
-            if("r1" !in params.input.paired || "r2" !in params.input.paired || "names" !in params.input.paired){
+            if("r" !in params.input.paired && ("r1" !in params.input.paired || "r2" !in params.input.paired || "names" !in params.input.paired)){
                 error "Missing parameter: --input.paired.r1 and --input.paired.r2 must be provided!"
             }
 

--- a/modules/qualityControl/shortReadQC.nf
+++ b/modules/qualityControl/shortReadQC.nf
@@ -18,7 +18,7 @@ process pFastpSplit {
     time params.steps.containsKey("qc") ? Utils.setTimeLimit(params.steps.qc.fastp, params.modules.qc.process.fastp.defaults, params.resources.highmemMedium) : ""
 
     input:
-    tuple val(sample), path(read1, stageAs: "read1.fq.gz"), path(read2, stageAs: "read2.fq.gz")
+    tuple val(sample), path(read1, stageAs: "read1.fq.gz"), path(read2, stageAs: "read2.fq.gz"), env(isInterleaved)
 
     output:
     tuple val("${sample}"), path("${sample}_interleaved.qc.fq.gz"), optional: true, emit: readsPair
@@ -202,7 +202,7 @@ process pFastpSplitDownload {
     containerOptions (params.apptainer ? "" : Utils.getDockerNetwork())
 
     input:
-    tuple val(sample), env(read1Url), env(read2Url)
+    tuple val(sample), env(read1Url), env(read2Url), env(isInterleaved)
 
     output:
     tuple val("${sample}"), path("${sample}_interleaved.qc.fq.gz"), optional: true, emit: readsPair
@@ -224,14 +224,22 @@ workflow _wFastqSplit {
        take:
          reads
        main:
+            READS_IDX=1
+
             // Check if files are S3 URLs and if the download parameter is specified in the config
             reads | branch {
-              download: it[2].startsWith("s3://") && params?.steps?.qc.fastp.containsKey("download")
+              download: it[READS_IDX].startsWith("s3://") && params?.steps?.qc.fastp.containsKey("download")
               noDownload: !params?.steps?.qc.fastp.containsKey("download")
              } | set { samples }
 
-             samples.noDownload | pFastpSplit 
-             samples.download | pFastpSplitDownload
+             // Check whether fastq files are in interleaved format 
+             samples.noDownload
+                | map { sample, reads1, reads2 -> [sample, reads1, reads2,  file(reads2).name == "empty"? true: false]} 
+                | pFastpSplit 
+
+             samples.download 
+                | map { sample, reads1, reads2 -> [sample, reads1, reads2,  file(reads2).name == "empty"? true: false]} 
+                | pFastpSplitDownload
 
              pFastpSplit.out.readsPair | mix(pFastpSplitDownload.out.readsPair) | set {readsPair}
              pFastpSplit.out.readsSingle | mix(pFastpSplitDownload.out.readsSingle) | set {readsSingle}

--- a/templates/fastpSplit.sh
+++ b/templates/fastpSplit.sh
@@ -2,15 +2,18 @@
 
 if [[ "\${isInterleaved}" == "true" ]]; then
        fastp -i read1.fq.gz --interleaved_in  ${reportOnly} \\
-              -o read1.fastp.fq.gz \\
-              -O read2.fastp.fq.gz \\
+              --stdout \\
        	-w ${task.cpus} -h ${sample}_report.html \\
-       	--unpaired1 ${sample}_tmp_unpaired.qc.fq.gz --unpaired2 ${sample}_tmp_unpaired.qc.fq.gz ${params.steps.qc.fastp.additionalParams.fastp}
+       	--unpaired1 ${sample}_tmp_unpaired.qc.fq.gz --unpaired2 ${sample}_tmp_unpaired.qc.fq.gz ${params.steps.qc.fastp.additionalParams.fastp} \\
+	| pigz --best --processes ${task.cpus} > ${sample}_tmp_interleaved.qc.fq.gz
 
 else
        fastp -i read1.fq.gz -I read2.fq.gz ${reportOnly} \\
-       	-w ${task.cpus} -h ${sample}_report.html \\
-       	--unpaired1 ${sample}_tmp_unpaired.qc.fq.gz --unpaired2 ${sample}_tmp_unpaired.qc.fq.gz ${params.steps.qc.fastp.additionalParams.fastp}
+       	-w ${task.cpus}  \\
+	-h ${sample}_report.html \\
+        --stdout \\
+       	--unpaired1 ${sample}_tmp_unpaired.qc.fq.gz --unpaired2 ${sample}_tmp_unpaired.qc.fq.gz ${params.steps.qc.fastp.additionalParams.fastp} \\
+	| pigz --best --processes ${task.cpus} > ${sample}_tmp_interleaved.qc.fq.gz
 fi
 
 # fix 'unexpected end of file' of unpaired reads gzip file
@@ -22,12 +25,6 @@ cat empty.txt.gz >> \${UNPAIRED}
 
 # create statistics for unpaired fastq files
 paste -d\$'\\t' <(echo -e "SAMPLE\\n${sample}") <(seqkit stats -T \${UNPAIRED}) > ${sample}_unpaired_summary.tsv
-
-# create interleaved fastq file for further analysis
-paste <(zcat read1.fastp.fq.gz)  <(zcat read2.fastp.fq.gz) \\
-       | paste - - - - \\
-       | awk -v OFS="\\n" -v FS="\\t" '{print(\$1,\$3,\$5,\$7,\$2,\$4,\$6,\$8)}' \\
-       | pigz --best --processes ${task.cpus} > ${sample}_tmp_interleaved.qc.fq.gz
 
 # create tables of the fastp summary
 cat fastp.json | jq -r  ' [.summary.before_filtering] | (map(keys) | add | unique) as \$cols | map(. as \$row | \$cols | map(\$row[.])) as \$rows | \$cols, \$rows[] | @tsv ' > fastp_summary_before_tmp.tsv

--- a/templates/fastpSplit.sh
+++ b/templates/fastpSplit.sh
@@ -1,7 +1,17 @@
 # run fastp
-fastp -i read1.fq.gz -I read2.fq.gz ${reportOnly} \\
-	-w ${task.cpus} -h ${sample}_report.html \\
-	--unpaired1 ${sample}_tmp_unpaired.qc.fq.gz --unpaired2 ${sample}_tmp_unpaired.qc.fq.gz ${params.steps.qc.fastp.additionalParams.fastp}
+
+if [[ "\${isInterleaved}" == "true" ]]; then
+       fastp -i read1.fq.gz --interleaved_in  ${reportOnly} \\
+              -o read1.fastp.fq.gz \\
+              -O read2.fastp.fq.gz \\
+       	-w ${task.cpus} -h ${sample}_report.html \\
+       	--unpaired1 ${sample}_tmp_unpaired.qc.fq.gz --unpaired2 ${sample}_tmp_unpaired.qc.fq.gz ${params.steps.qc.fastp.additionalParams.fastp}
+
+else
+       fastp -i read1.fq.gz -I read2.fq.gz ${reportOnly} \\
+       	-w ${task.cpus} -h ${sample}_report.html \\
+       	--unpaired1 ${sample}_tmp_unpaired.qc.fq.gz --unpaired2 ${sample}_tmp_unpaired.qc.fq.gz ${params.steps.qc.fastp.additionalParams.fastp}
+fi
 
 # fix 'unexpected end of file' of unpaired reads gzip file
 touch empty.txt

--- a/templates/fastpSplitDownload.sh
+++ b/templates/fastpSplitDownload.sh
@@ -13,8 +13,11 @@ fi
 
 fastp -i inputReads1.fq.gz \\
       -I inputReads2.fq.gz \\
-      -o read1.fastp.fq.gz -O read2.fastp.fq.gz -w ${task.cpus} -h ${sample}_report.html \\
-         --unpaired1 ${sample}_tmp_unpaired.qc.fq.gz --unpaired2 ${sample}_tmp_unpaired.qc.fq.gz ${params.steps.qc.fastp.additionalParams.fastp}
+      --stdout \\
+      -w ${task.cpus} \\
+      -h ${sample}_report.html \\
+       --unpaired1 ${sample}_tmp_unpaired.qc.fq.gz --unpaired2 ${sample}_tmp_unpaired.qc.fq.gz ${params.steps.qc.fastp.additionalParams.fastp} \\
+	| pigz --best --processes ${task.cpus} > ${sample}_tmp_interleaved.qc.fq.gz
 
 # This if statement solves issue https://github.com/pbelmann/meta-omics-toolkit/issues/166
 if grep -q "reset by peer" error1.log error2.log; then
@@ -33,12 +36,6 @@ cat empty.txt.gz >> \${UNPAIRED}
 
 # create statistics for unpaired fastq files
 paste -d\$'\\t' <(echo -e "SAMPLE\\n${sample}") <(seqkit stats -T \${UNPAIRED}) > ${sample}_unpaired_summary.tsv
-
-# create interleaved fastq file for further analysis
-paste <(zcat read1.fastp.fq.gz)  <(zcat read2.fastp.fq.gz) \\
-       | paste - - - - \\
-       | awk -v OFS="\\n" -v FS="\\t" '{print(\$1,\$3,\$5,\$7,\$2,\$4,\$6,\$8)}' \\
-       | pigz --best --processes ${task.cpus} > ${sample}_tmp_interleaved.qc.fq.gz
 
 # create tables of the fastp summary
 cat fastp.json | jq -r  ' [.summary.before_filtering] | (map(keys) | add | unique) as \$cols | map(. as \$row | \$cols | map(\$row[.])) as \$rows | \$cols, \$rows[] | @tsv ' > fastp_summary_before_tmp.tsv

--- a/templates/fastpSplitDownload.sh
+++ b/templates/fastpSplitDownload.sh
@@ -2,8 +2,14 @@
 
 set -o pipefail
 
-s5cmd ${params.steps.qc.fastp.download.s5cmdParams} cat  --concurrency ${task.cpus} \${read1Url} 2> error1.log  > inputReads1.fq.gz
-s5cmd ${params.steps.qc.fastp.download.s5cmdParams} cat  --concurrency ${task.cpus} \${read2Url} 2> error2.log  > inputReads2.fq.gz
+if [[ "\${isInterleaved}" == "true" ]]; then
+    s5cmd ${params.steps.qc.fastp.download.s5cmdParams} cat  --concurrency ${task.cpus} \${read1Url} 2> error1.log  \\
+       | zcat | paste - - - - - - - -  | tee >(cut -f 1-4 | tr "\t" "\n" | pigz --best --processes ${task.cpus} > inputReads1.fq.gz)  \\
+       | cut -f 5-8 | tr "\t" "\n" | pigz --best --processes ${task.cpus} > inputReads2.fq.gz
+else
+    s5cmd ${params.steps.qc.fastp.download.s5cmdParams} cat  --concurrency ${task.cpus} \${read1Url} 2> error1.log  > inputReads1.fq.gz
+    s5cmd ${params.steps.qc.fastp.download.s5cmdParams} cat  --concurrency ${task.cpus} \${read2Url} 2> error2.log  > inputReads2.fq.gz
+fi
 
 fastp -i inputReads1.fq.gz \\
       -I inputReads2.fq.gz \\

--- a/test_data/fullPipeline/reads_split_interleaved.tsv
+++ b/test_data/fullPipeline/reads_split_interleaved.tsv
@@ -1,0 +1,3 @@
+SAMPLE	READS
+test1	https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta_test/small/read2_1.fq.gz
+test2	https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta_test/small/read2_1.fq.gz

--- a/test_data/fullPipeline/reads_split_s3_interleaved.tsv
+++ b/test_data/fullPipeline/reads_split_s3_interleaved.tsv
@@ -1,0 +1,3 @@
+SAMPLE	READS
+test1	s3://meta_test/small/read2_1.fq.gz
+test2	s3://meta_test/small/read2_1.fq.gz

--- a/test_data/input/interleavedExpected.tsv
+++ b/test_data/input/interleavedExpected.tsv
@@ -1,0 +1,2 @@
+SAMPLE	INSTRUMENT	MULTI_BINNING_GROUP	READS1	READS2
+test1	ILLUMINA	null	/swift/v1/meta_test/small/read1_1bla.fq.gz	

--- a/test_data/input/reads_interleaved.tsv
+++ b/test_data/input/reads_interleaved.tsv
@@ -1,0 +1,3 @@
+SAMPLE	READS
+test1	https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta_test/small/read2_1.fq.gz
+test2	https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/meta_test/small/read2_1.fq.gz


### PR DESCRIPTION
This PR enables the Toolkit to accept reads in an interleaved format. This makes it easier to handle simulated reads generated in CAMI, which are always in this format.

Providing reads on the command line can be achieved using the '--input.paired.r' option.
Spreadsheets can contain just a 'READS' column instead of 'READS1' and 'READS2'.

## PR review guidelines

Thank you for submitting this PR.

Before merge:

* A PR must be reviewed by one of the team members.

* Please check if anything in the documentation must be adjusted, or added (development-setup, production-setup, user-guide).

* PRs with new modules or workflow interfaces must include tests according to the developer [guidelines](https://metagenomics.github.io/metagenomics-tk/latest/developer_guidelines/).

* The new code is readable, well commented and should adhere to our developer [guidelines](https://metagenomics.github.io/metagenomics-tk/latest/developer_guidelines/).

* Before merging it must be checked if a squash of commits is required.

### Config updates

If you update any of the config files in the default folder, please make sure to also update the `clowm/nextflow_schema.json` if necessary.  

