### PR TITLE
fix(binning): prevent empty binning results

### DIFF
--- a/modules/binning/multiBinning.nf
+++ b/modules/binning/multiBinning.nf
@@ -254,7 +254,9 @@ workflow _wBinningLongRead {
             contigs,
         )
 
-        wMultiBinningSemiBin2ONT.out.bins | set { bins }
+        wMultiBinningSemiBin2ONT.out.bins 
+	| filter { sample, bins -> bins.size() > 0}
+	| set { bins }
 
         wMultiBinningSemiBin2ONT.out.notBinned | set { notBinned }
 
@@ -407,7 +409,9 @@ workflow _wBinningShortRead {
             contigs,
         )
 
-        wMultiBinningSemiBin2.out.bins | set { bins }
+        wMultiBinningSemiBin2.out.bins 
+	| filter { sample, bins -> bins.size() > 0}
+	| set { bins }
 
         wMultiBinningSemiBin2.out.notBinned | set { notBinned }
 

--- a/modules/binning/ontBinning.nf
+++ b/modules/binning/ontBinning.nf
@@ -38,7 +38,7 @@ process pMetaCoAG {
     tuple val(sample), path(graph), path(contigs), path(bam), path(headerMapping), path(flyeAssemblyInfo)
 
     output:
-    tuple val("${sample}"), path("${sample}_bin.*.fa", arity: '1..*'), optional: true, emit: bins
+    tuple val("${sample}"), path("${sample}_bin.*.fa", arity: '0..*'), emit: bins
     tuple val("${sample}"), file("${sample}_notBinned.fa"), optional: true, emit: notBinned
     tuple val("${sample}"), file("${sample}_bin_contig_mapping.tsv"), optional: true, emit: binContigMapping
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
@@ -183,9 +183,9 @@ workflow _wRunBinningTools {
         contigs | join(mappedReads, by: SAMPLE_IDX),
     )
 
-    pMetabat.out.bins
-        | mix(pSemiBin2.out.bins)
-        | mix(pMetaCoAG.out.bins)
+    pMetabat.out.bins | filter { sample, bins -> bins.size() > 0}
+        | mix(pSemiBin2.out.bins | filter { sample, bins -> bins.size() > 0})
+        | mix(pMetaCoAG.out.bins | filter { sample, bins -> bins.size() > 0})
         | set { bins }
 
 

--- a/modules/binning/processes.nf
+++ b/modules/binning/processes.nf
@@ -355,7 +355,7 @@ process pMetabat {
     tuple val(sample), path(contigs), path(bam), val(medianQuality)
 
     output:
-    tuple val("${sample}"), path("${sample}_bin.*.fa", arity: '1..*'), optional: true, emit: bins
+    tuple val("${sample}"), path("${sample}_bin.*.fa", arity: '0..*'), emit: bins
     tuple val("${sample}"), file("${sample}_notBinned.fa"), optional: true, emit: notBinned
     tuple val("${sample}"), file("${sample}_bin_contig_mapping.tsv"), optional: true, emit: binContigMapping
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
@@ -390,7 +390,7 @@ process pSemiBin2 {
     tuple val(sample), path(contigs), path(bam)
 
     output:
-    tuple val("${sample}"), path("${sample}_bin.*.fa", arity: '1..*'), optional: true, emit: bins
+    tuple val("${sample}"), path("${sample}_bin.*.fa", arity: '0..*'), emit: bins
     tuple val("${sample}"), file("${sample}_notBinned.fa"), optional: true, emit: notBinned
     tuple val("${sample}"), file("${sample}_bin_contig_mapping.tsv"), optional: true, emit: binContigMapping
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
@@ -459,7 +459,7 @@ process pSemiBin2Binning {
         path(featureOutput), path(compressedFeatureOutput), path(sampleGroupsFile) 
 
     output:
-    tuple val("${sample}"), path("${sample}_bin.*.fa", arity: '1..*'), optional: true, emit: bins
+    tuple val("${sample}"), path("${sample}_bin.*.fa", arity: '0..*'), emit: bins
     tuple val("${sample}"), file("${sample}_notBinned.fa"), optional: true, emit: notBinned
     tuple val("${sample}"), path("${sampleGroupsFile}", includeInputs: true), optional: true, emit: groupsFile 
     tuple val("${sample}"), file("${sample}_bin_contig_mapping.tsv"), optional: true, emit: binContigMapping

--- a/modules/binning/shortReadBinning.nf
+++ b/modules/binning/shortReadBinning.nf
@@ -34,7 +34,7 @@ process pMetabinner {
     tuple val(sample), path(contigs), path(bam)
 
     output:
-    tuple val("${sample}"), path("${sample}_bin.*.fa", arity: '1..*'), optional: true, emit: bins
+    tuple val("${sample}"), path("${sample}_bin.*.fa", arity: '0..*'), emit: bins
     tuple val("${sample}"), file("${sample}_notBinned.fa"), optional: true, emit: notBinned
     tuple val("${sample}"), file("${sample}_bin_contig_mapping.tsv"), optional: true, emit: binContigMapping
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
@@ -80,7 +80,7 @@ process pMAGScoT {
     output:
     tuple val("${sample}"), file("${sample}_MagScoT.*"), optional: true, emit: scores
     tuple val("${sample}"), file("${sample}_bin_contig_mapping.tsv"), optional: true, emit: binContigMapping
-    tuple val("${sample}"), path("${sample}_bin.*.fa", arity: '1..*'), optional: true, emit: bins
+    tuple val("${sample}"), path("${sample}_bin.*.fa", arity: '0..*'), emit: bins
     tuple val("${sample}"), file("${sample}_notBinned.fa"), optional: true, emit: notBinned
     tuple file(".command.sh"), file(".command.out"), file(".command.err"), file(".command.log")
 
@@ -249,10 +249,11 @@ workflow _wRunBinningTools {
         binningInput | combine(channel.value(DO_NOT_ESTIMATE_IDENTITY)),
     )
 
-    pMetabinner.out.bins
-        | mix(pMetabat.out.bins)
-        | mix(pSemiBin2.out.bins)
+    pMetabat.out.bins | filter { sample, bins -> bins.size() > 0}
+        | mix(pSemiBin2.out.bins | filter { sample, bins -> bins.size() > 0})
+        | mix(pMetabinner.out.bins | filter { sample, bins -> bins.size() > 0})
         | set { bins }
+
     pMetabinner.out.notBinned
         | mix(pSemiBin2.out.notBinned)
         | mix(pMetabat.out.notBinned)


### PR DESCRIPTION
The following output definition does not accept no process output:
`tuple val("${sample}"), path("${sample}_bin.*.fa", arity: "1..*"), optional: true, emit: bins` Setting 'optional' has no effect.

## PR review guidelines

Thank you for submitting this PR.

Before merge:

* A PR must be reviewed by one of the team members.

* Please check if anything in the documentation must be adjusted, or added (development-setup, production-setup, user-guide).

* PRs with new modules or workflow interfaces must include tests according to the developer [guidelines](https://metagenomics.github.io/metagenomics-tk/latest/developer_guidelines/).

* The new code is readable, well commented and should adhere to our developer [guidelines](https://metagenomics.github.io/metagenomics-tk/latest/developer_guidelines/).

* Before merging it must be checked if a squash of commits is required.

### Config updates

If you update any of the config files in the default folder, please make sure to also update the `clowm/nextflow_schema.json` if necessary.  

